### PR TITLE
Remove Builder JSX loc plugin to resolve Vite peer conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
-    "@builder.io/vite-plugin-jsx-loc": "^0.1.1",
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.1.3",
     "@types/express": "4.17.21",


### PR DESCRIPTION
## Summary
- remove the optional `@builder.io/vite-plugin-jsx-loc` dev dependency that blocks Vite 7 installs
- keep the Vite configuration untouched since the plugin was not referenced in the project

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694280e23394832a8a385fdd195aedd6)