### PR TITLE
docs: include black beans in raw-toxicity guidance

### DIFF
--- a/v3-webapp/README.md
+++ b/v3-webapp/README.md
@@ -17,7 +17,7 @@ The calculator starts with your own inventory. Add the ingredients and amounts y
 
 ## A note about safe feeding
 
-This planner helps organise seed and grain mixes; it does not replace appropriate complete feeding, careful observation, or individual care. Preparation reminders matter: some legumes require the correct feed-grade processing, and raw kidney beans, lima beans, fava beans, navy beans, and pinto beans must never be fed.
+This planner helps organise seed and grain mixes; it does not replace appropriate complete feeding, careful observation, or individual care. Preparation reminders matter: some legumes require the correct feed-grade processing, and raw kidney beans, lima beans, fava beans, navy beans, pinto beans, and black beans must never be fed.
 
 The calculator intentionally keeps a clear distinction between **critical safety warnings**, ordinary preparation guidance, and mix recommendations. If an ingredient does not appear for a chosen bird, use the inventory search to see whether it is incompatible or needs special handling.
 

--- a/v3-webapp/client/src/lib/safety.ts
+++ b/v3-webapp/client/src/lib/safety.ts
@@ -231,7 +231,7 @@ export const SAFETY_DISCLAIMER = `
 ⚠️ **IMPORTANT SAFETY REMINDERS:**
 - **Fresh Water**: Always provide clean, fresh water available at all times
 - **Grit**: Pigeons need grit to properly digest seeds and grains
-- **Toxic Legumes**: Never feed raw kidney beans, lima beans, fava beans, navy beans, or pinto beans - they contain deadly toxins
+- **Toxic Legumes**: Never feed raw kidney beans, lima beans, fava beans, navy beans, pinto beans, or black beans - they contain deadly toxins
 - **Preparation**: Follow preparation instructions for each ingredient carefully
 - **Exotics Vet Care**: If your pigeon shows signs of illness, contact an exotics vet immediately
 `;

--- a/v3-webapp/client/src/pages/Home.tsx
+++ b/v3-webapp/client/src/pages/Home.tsx
@@ -346,7 +346,7 @@ export default function Home() {
           </section>
         </div>
 
-        <section className="mt-16 border-t pt-8" aria-label="Safety reminders"><Alert className="border-amber-200 bg-amber-50"><AlertTriangle className="h-4 w-4 text-amber-600" /><AlertTitle className="font-bold text-amber-900">Important Safety Reminders</AlertTitle><AlertDescription className="mt-2 space-y-2 text-sm text-amber-800"><p>Fresh Water: Always provide clean, fresh water available at all times</p><p>Grit: Pigeons need grit to properly digest seeds and grains</p><p>Toxic Legumes: Never feed raw kidney beans, lima beans, fava beans, navy beans, or pinto beans</p><p>Preparation: Follow preparation instructions for each ingredient carefully</p><p>Exotics Vet Care: If your pigeon shows signs of illness, contact an exotics vet immediately</p></AlertDescription></Alert></section>
+        <section className="mt-16 border-t pt-8" aria-label="Safety reminders"><Alert className="border-amber-200 bg-amber-50"><AlertTriangle className="h-4 w-4 text-amber-600" /><AlertTitle className="font-bold text-amber-900">Important Safety Reminders</AlertTitle><AlertDescription className="mt-2 space-y-2 text-sm text-amber-800"><p>Fresh Water: Always provide clean, fresh water available at all times</p><p>Grit: Pigeons need grit to properly digest seeds and grains</p><p>Toxic Legumes: Never feed raw kidney beans, lima beans, fava beans, navy beans, pinto beans, or black beans</p><p>Preparation: Follow preparation instructions for each ingredient carefully</p><p>Exotics Vet Care: If your pigeon shows signs of illness, contact an exotics vet immediately</p></AlertDescription></Alert></section>
       </main>
     </div>
   );

--- a/v3-webapp/todo.md
+++ b/v3-webapp/todo.md
@@ -74,4 +74,7 @@
 - [x] Move the root comparison utility into the data documentation area and repair its path references.
 - [x] Preserve the original V1 README in V0 as a clearly labelled historical companion document.
 - [x] Rewrite the V3 README for bird keepers and prospective users rather than developers, while keeping accurate safety and scope guidance.
-- [ ] Post a completion summary on GitHub Issue #10 and close only that issue after the simplified layout is validated and pushed.
+- [x] Post a completion summary on GitHub Issue #10 and close only that issue after the simplified layout is validated and pushed.
+- [x] Add black beans to the V3 raw-toxicity README list and verify it matches active safety rules.
+- [x] Explain the scope and visible output of Codex’s PR #12 review.
+- [x] Identify the Codex review integration credential model and recommend secure free or low-cost automatic repository-maintenance options for approval.


### PR DESCRIPTION
## Purpose

Addresses Codex review feedback on merged PR #12.

## Change

Adds **black beans** to the raw-toxicity lists in all three keeper-facing places:

- V3 keeper README
- Shared safety reminder
- Visible in-app safety panel

This matches the existing critical `black_beans` safety record; no ingredient value, formula target, or eligibility logic changed.

## Validation

- `pnpm check`
- `pnpm test:calculator` — 21 scenarios passed
- `pnpm build`
- Search confirms every enumerated raw-bean warning now includes black beans.