### PR TITLE
fix: run Firebase deployment workflow from V3 workspace

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Firebase Hosting and Functions
+name: Deploy to Firebase Hosting
 
 on:
   push:
@@ -20,22 +20,23 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 9
+          version: 10.4.1
           run_install: false
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Install V3 application dependencies
+        run: pnpm --dir v3-webapp install --frozen-lockfile
 
       - name: Run verification checks
         run: |
-          pnpm check
-          pnpm build
-          pnpm test:calculator
+          pnpm --dir v3-webapp check
+          pnpm --dir v3-webapp test:calculator
+          pnpm --dir v3-webapp test:herb-safety
+          pnpm --dir v3-webapp build
 
       - name: Build Firebase Functions
         run: |
-          cd functions
-          npm install
+          cd v3-webapp/functions
+          npm ci
           npm run build
 
       - name: Deploy to Firebase
@@ -45,5 +46,6 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_BIRD_FOOD_CALCULATOR_25E6D }}'
           channelId: live
           projectId: bird-food-calculator-25e6d
+          entryPoint: v3-webapp
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks

--- a/v3-webapp/todo.md
+++ b/v3-webapp/todo.md
@@ -92,3 +92,4 @@
 - [ ] Define and implement a source-backed herb knowledge-base view that displays the academic sources stored with each herb record, while preserving the concise calculator cards.
 - [ ] Trace and restore the optimized-mix ingredient-diversity suggestion box when a valid batch estimate does not currently surface it.
 - [ ] Make raw adzuki-bean safety messaging explicit and red while retaining its approved cooked or properly processed guidance.
+- [x] Repair the GitHub Actions Firebase deployment workflow so it installs and verifies dependencies inside v3-webapp before deploying merged main.


### PR DESCRIPTION
## Why\n\nThe first main-branch Firebase deployment after PR #31 failed before building because the workflow installed dependencies at the repository root, while the V3 application and its lockfile live in `v3-webapp/`. It also referenced a non-existent root `functions/` directory.\n\n## Change\n\n- install and verify dependencies through `pnpm --dir v3-webapp`;\n- run the calculator and herb-safety checks before the production build;\n- build Cloud Functions from `v3-webapp/functions`;\n- set the Firebase Hosting action entry point to `v3-webapp`; and\n- align the pnpm action version with the repository’s pinned major version.\n\n## Validation\n\nThe revised commands passed locally: TypeScript, 21-scenario calculator verification, 26-record herb-safety verification, production build, and Functions TypeScript build.\n\nThis PR does not merge or deploy by itself; after owner review and merge, the repaired workflow deploys merged `main` to Firebase Hosting.