### PR TITLE
feat: add occasional pigeon Pet/Companion garlic oil

### DIFF
--- a/database/herb-provenance.mts
+++ b/database/herb-provenance.mts
@@ -134,7 +134,7 @@ export const HERB_EVIDENCE: Record<string, HerbEvidence> = {
   chamomile: eligible(["dardouri2025", "elSabrout2023"], "Poultry evidence; no individual companion-bird dose is asserted."),
   neem: libraryOnly(["hartady2021"], "Published poultry and avian literature is mixed by plant part and preparation, so it is reference-only until a species and preparation review is completed."),
   apple_cider_vinegar: libraryOnly(["vanImmerseel2007"], "Organic-acid poultry literature is not an apple-cider-vinegar-specific drinking-water protocol."),
-  garlic_oil: pigeonEligible(["wade2004", "hartady2021"], "The preserved pigeon racing and winter formulations include garlic oil. It remains automatically suggested for pigeons only. The cited companion-bird case report is a non-pigeon caution and does not establish a general pigeon exclusion."),
+  garlic_oil: pigeonEligible(["wade2004", "hartady2021"], "The preserved pigeon racing and winter formulations include garlic oil; the owner has also approved it as an occasional Pet/Companion option for pigeons. It remains automatically suggested for pigeons only. The cited companion-bird case report is a non-pigeon caution and does not establish a general pigeon exclusion."),
   hemp_oil: eligible(["gao2021"], "Poultry dietary-oil review; product composition and total dietary fat still require review."),
   cod_liver_oil: libraryOnly([], "No linked academic avian source has yet been recorded for this individual planner entry; vitamin A and D concentration must be product-specific."),
   linseed_oil: eligible(["gao2021"], "Poultry dietary-oil review; product composition and total dietary fat still require review."),

--- a/v3-webapp/client/src/lib/data.ts
+++ b/v3-webapp/client/src/lib/data.ts
@@ -304,8 +304,8 @@ export const HERBS_SUPPLEMENTS: Record<string, Herb> = {
 
 export const HERB_RECOMMENDATIONS: Record<string, { recommended: string[]; notes: string }> = {
     "pet": {
-        "recommended": ["chamomile", "fennel", "anise", "oregano", "thyme"],
-        "notes": "Stress relief, digestive health, odor reduction, general wellness for companion birds"
+        "recommended": ["chamomile", "fennel", "anise", "oregano", "thyme", "garlic_oil"],
+        "notes": "Stress relief, digestive health, odor reduction, general wellness for companion birds; garlic oil is an occasional pigeon-only option"
     },
     "maintenance": {
         "recommended": ["apple_cider_vinegar", "garlic_powder", "oregano"],

--- a/v3-webapp/scripts/verify-herb-safety.mjs
+++ b/v3-webapp/scripts/verify-herb-safety.mjs
@@ -38,11 +38,21 @@ for (const allium of ["garlic_powder", "garlic_oil"]) {
 
 const pigeonMaintenance = getEligibleHerbNames(HERB_RECOMMENDATIONS.maintenance.recommended, "pigeon");
 const pigeonRacing = getEligibleHerbNames(HERB_RECOMMENDATIONS.racing.recommended, "pigeon");
+const pigeonPet = getEligibleHerbNames(HERB_RECOMMENDATIONS.pet.recommended, "pigeon");
 if (!pigeonMaintenance.includes("garlic_powder")) {
   throw new Error("pigeon maintenance must retain garlic powder");
 }
 if (!pigeonRacing.includes("garlic_oil")) {
   throw new Error("pigeon racing must retain garlic oil");
+}
+if (!pigeonPet.includes("garlic_oil")) {
+  throw new Error("pigeon Pet/Companion must retain garlic oil as an occasional option");
+}
+for (const bird of BIRD_TYPES.filter((bird) => bird !== "pigeon")) {
+  const nonPigeonPet = getEligibleHerbNames(HERB_RECOMMENDATIONS.pet.recommended, bird);
+  if (nonPigeonPet.includes("garlic_oil")) {
+    throw new Error(`Pet/Companion must not automatically suggest garlic oil for ${bird}`);
+  }
 }
 
 console.log(`Verified evidence and automatic-suggestion safety for ${Object.keys(HERBS_SUPPLEMENTS).length} herb and supplement records across ${BIRD_TYPES.length} bird types.`);

--- a/v3-webapp/todo.md
+++ b/v3-webapp/todo.md
@@ -92,3 +92,4 @@
 - [ ] Define and implement a source-backed herb knowledge-base view that displays the academic sources stored with each herb record, while preserving the concise calculator cards.
 - [ ] Trace and restore the optimized-mix ingredient-diversity suggestion box when a valid batch estimate does not currently surface it.
 - [ ] Make raw adzuki-bean safety messaging explicit and red while retaining its approved cooked or properly processed guidance.
+- [x] Add garlic oil as an occasional pigeon-only Pet/Companion recommendation through the canonical herb provenance database, without changing other bird recommendations.


### PR DESCRIPTION
## Linked issue

Closes #35

## Scope

Adds garlic oil to the existing Pet/Companion recommendation list as an **occasional option for pigeons only**, as approved by the product owner. The bird-aware eligibility registry continues to exclude it from parrot, African Grey, budgie, canary, and chicken automatic suggestions.

## Data and decision record

The scope is recorded in the canonical `database/herb-provenance.mts` registry and consumed through the established V3 adapter. No dosage, frequency, nutrient value, or unrelated formulation entry changes.

## Validation

- TypeScript check passed.
- Herb-safety verification confirms pigeon Pet/Companion inclusion and non-pigeon exclusion.
- 21-scenario calculator verification passed.
- Production build passed.

## Follow-up

This PR is intentionally limited to the owner-approved pigeon Pet/Companion change. The repository-wide issue-linked workflow is tracked separately in PR #37 / Issue #36.
