### PR TITLE
fix(actions): allow report processor dependency install with legacy peer deps

### DIFF
--- a/.github/workflows/process-reports.yml
+++ b/.github/workflows/process-reports.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Dependencies
         run: |
           cd v3-webapp
-          npm install firebase-admin axios
+          npm install --legacy-peer-deps firebase-admin axios
 
       - name: Run Report Processor
         env:


### PR DESCRIPTION
Fixes issue where GitHub Actions report processor fails at 'Install Dependencies' due to npm peer dependency conflict between Vite 7 and @builder.io/vite-plugin-jsx-loc in v3-webapp. Uses --legacy-peer-deps specifically for the queue processor runner step.