### PR TITLE
feat: restore profile standard inventory reset

### DIFF
--- a/v3-webapp/client/src/pages/Home.tsx
+++ b/v3-webapp/client/src/pages/Home.tsx
@@ -12,6 +12,7 @@ import {
   Info,
   Leaf,
   Plus,
+  RotateCcw,
   Scale,
   Search,
   Trash2,
@@ -153,6 +154,12 @@ export default function Home() {
       delete updated[name];
       return updated;
     });
+  };
+
+  const resetToStandardMix = () => {
+    setInventory(getStarterInventory(selectedBird, situation));
+    setIngredientSearch("");
+    setAddOpen(false);
   };
 
   const exportRecipe = () => {
@@ -311,6 +318,7 @@ export default function Home() {
                 <CardDescription>Enter the available amount of each ingredient in grams. Unsafe or incompatible ingredients are not offered for this bird.</CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
+                <div className="grid gap-2 sm:grid-cols-2">
                 <Popover open={addOpen} onOpenChange={setAddOpen}>
                   <PopoverTrigger asChild>
                     <Button type="button" variant="outline" className="w-full justify-start gap-2"><Plus className="h-4 w-4" />Add compatible ingredient</Button>
@@ -337,6 +345,10 @@ export default function Home() {
                     </ScrollArea>
                   </PopoverContent>
                 </Popover>
+                  <Button type="button" variant="outline" className="w-full justify-start gap-2" onClick={resetToStandardMix} title={`Restore the ${birdProfile.name} ${currentProfile.name} standard inventory`}>
+                    <RotateCcw className="h-4 w-4" />Reset to standard mix
+                  </Button>
+                </div>
 
                 <div className="space-y-3">
                   {Object.entries(inventory).map(([name, amount]) => {

--- a/v3-webapp/package.json
+++ b/v3-webapp/package.json
@@ -13,6 +13,7 @@
     "check": "tsc --noEmit",
     "test:calculator": "tsx scripts/verify-calculator.mjs",
     "test:herb-safety": "tsx scripts/verify-herb-safety.mjs",
+    "test:inventory-presets": "tsx scripts/verify-inventory-presets.mjs",
     "test:github-app": "tsx scripts/verify-github-app-auth.mjs",
     "format": "prettier --write ."
   },

--- a/v3-webapp/scripts/verify-inventory-presets.mjs
+++ b/v3-webapp/scripts/verify-inventory-presets.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { getStarterInventory } from "../client/src/lib/inventory-presets.ts";
+
+const pigeonPet = getStarterInventory("pigeon", "pet");
+assert.deepEqual(pigeonPet, {
+  wheat: 5000,
+  corn_yellow: 3000,
+  peas: 2000,
+  lentils: 1000,
+  safflower: 500,
+  barley: 2000,
+});
+
+const pigeonRacing = getStarterInventory("pigeon", "racing");
+assert.notDeepEqual(pigeonPet, pigeonRacing, "profiles must preserve distinct standard inventories");
+
+pigeonPet.wheat = 1;
+assert.equal(
+  getStarterInventory("pigeon", "pet").wheat,
+  5000,
+  "reset inventories must be fresh copies rather than mutable shared presets",
+);
+
+assert.deepEqual(
+  getStarterInventory("chicken", "unknown-profile"),
+  getStarterInventory("chicken", "pet"),
+  "unsupported profile values must fall back to a safe standard inventory",
+);
+
+console.log("Inventory preset checks passed.");

--- a/v3-webapp/todo.md
+++ b/v3-webapp/todo.md
@@ -95,3 +95,5 @@
 - [x] Add garlic oil as an occasional pigeon-only Pet/Companion recommendation through the canonical herb provenance database, without changing other bird recommendations.
 - [x] Repair the GitHub Actions Firebase deployment workflow so it installs and verifies dependencies inside v3-webapp before deploying merged main.
 - [x] Adopt an issue-linked pull-request workflow with concise scope, validation, decision, and handoff comments for every substantive repository change.
+- [x] Reimplement and validate the missing "Reset to standard mix" control for GitHub Issue #39 on an issue-linked review branch.
+- [x] Add automated coverage confirming profile-specific inventory presets remain distinct and resettable without shared mutation.


### PR DESCRIPTION
## Scope
Implements #39 with a focused **Reset to standard mix** control in the inventory card. It restores the canonical starter inventory for the selected bird and current profile.

## Behaviour
- Resets only editable inventory amounts and ingredients.
- Clears the open inventory search state.
- Does not change nutrition targets, profile data, safety rules, or optimizer behaviour.

## Validation
- `pnpm --dir v3-webapp check`
- `pnpm --dir v3-webapp run test:inventory-presets`
- `pnpm --dir v3-webapp run test:calculator`
- `pnpm --dir v3-webapp build`
- Browser check: changed Pigeon / Pet-Companion wheat from 5000 g to 123 g, then verified reset restored 5000 g.

## Owner review requested
Please review the preview before approving. This PR is not merged.