### PR TITLE
fix: queue reports after Firebase Hosting fallback

### DIFF
--- a/v3-webapp/client/src/components/IssueSubmitDialog.tsx
+++ b/v3-webapp/client/src/components/IssueSubmitDialog.tsx
@@ -15,6 +15,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { AlertCircle, CheckCircle2, ExternalLink, Loader2, Send } from "lucide-react";
 import { collection, addDoc, serverTimestamp } from "firebase/firestore";
 import { db } from "@/lib/firebase";
+import { parseIssueCreationResponse } from "@/lib/issue-submission";
 
 interface IssueSubmitDialogProps {
   triggerLabel: React.ReactNode;
@@ -65,15 +66,14 @@ export function IssueSubmitDialog({
         body: JSON.stringify({ title, body, labels }),
       });
       const text = await response.text();
-      let data: { html_url?: string; error?: string } = {};
-      try {
-        data = text ? JSON.parse(text) : {};
-      } catch {
-        data = { error: text || "Server returned an invalid response." };
-      }
-      if (!response.ok) throw new Error(data.error || `Server error (${response.status})`);
+      const data = parseIssueCreationResponse({
+        ok: response.ok,
+        status: response.status,
+        contentType: response.headers.get("content-type"),
+        body: text,
+      });
 
-      setGithubUrl(data.html_url || directGithubUrl);
+      setGithubUrl(data.html_url);
       setSubmissionMode("created");
       return;
     } catch {

--- a/v3-webapp/client/src/lib/issue-submission.ts
+++ b/v3-webapp/client/src/lib/issue-submission.ts
@@ -1,0 +1,35 @@
+export type IssueCreationResponse = {
+  html_url: string;
+};
+
+type HttpResponseMetadata = {
+  ok: boolean;
+  status: number;
+  contentType: string | null;
+  body: string;
+};
+
+/**
+ * Accept only a real JSON response containing a GitHub issue URL. Firebase
+ * Hosting serves the SPA document with HTTP 200 for unavailable `/api/*`
+ * paths, which must fall through to the Firestore review queue instead.
+ */
+export function parseIssueCreationResponse({ ok, status, contentType, body }: HttpResponseMetadata): IssueCreationResponse {
+  if (!ok) throw new Error(`Server error (${status})`);
+  if (!contentType?.toLowerCase().includes("application/json")) {
+    throw new Error("The in-app reporting service did not return a GitHub issue response.");
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(body);
+  } catch {
+    throw new Error("The in-app reporting service returned invalid JSON.");
+  }
+
+  if (!data || typeof data !== "object" || typeof (data as { html_url?: unknown }).html_url !== "string") {
+    throw new Error("The in-app reporting service did not create a GitHub issue.");
+  }
+
+  return data as IssueCreationResponse;
+}

--- a/v3-webapp/package.json
+++ b/v3-webapp/package.json
@@ -14,6 +14,7 @@
     "test:calculator": "tsx scripts/verify-calculator.mjs",
     "test:herb-safety": "tsx scripts/verify-herb-safety.mjs",
     "test:inventory-presets": "tsx scripts/verify-inventory-presets.mjs",
+    "test:issue-submission": "tsx scripts/verify-issue-submission.mjs",
     "test:github-app": "tsx scripts/verify-github-app-auth.mjs",
     "format": "prettier --write ."
   },

--- a/v3-webapp/scripts/verify-issue-submission.mjs
+++ b/v3-webapp/scripts/verify-issue-submission.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { parseIssueCreationResponse } from "../client/src/lib/issue-submission.ts";
+
+const issue = parseIssueCreationResponse({
+  ok: true,
+  status: 201,
+  contentType: "application/json; charset=utf-8",
+  body: '{"html_url":"https://github.com/Crypto-Shroom/Bird-Feed-Calculator/issues/99"}',
+});
+assert.equal(issue.html_url, "https://github.com/Crypto-Shroom/Bird-Feed-Calculator/issues/99");
+
+assert.throws(
+  () => parseIssueCreationResponse({ ok: true, status: 200, contentType: "text/html; charset=utf-8", body: "<html>SPA fallback</html>" }),
+  /did not return a GitHub issue response/,
+  "Firebase Hosting HTML fallback must proceed to the Firestore queue",
+);
+
+assert.throws(
+  () => parseIssueCreationResponse({ ok: true, status: 200, contentType: "application/json", body: "{}" }),
+  /did not create a GitHub issue/,
+  "JSON responses without a created issue URL must proceed to the Firestore queue",
+);
+
+assert.throws(
+  () => parseIssueCreationResponse({ ok: false, status: 404, contentType: "application/json", body: '{"error":"Not found"}' }),
+  /Server error \(404\)/,
+);
+
+console.log("Issue submission fallback checks passed.");


### PR DESCRIPTION
## Scope
Fixes #19’s live reporting path on Firebase Hosting. The deployed static host returns the calculator HTML with HTTP 200 for `/api/submit-issue`; the prior client treated that HTML document as a successfully created GitHub issue.

## Change
The client now recognises a direct submission only when it receives JSON containing a GitHub issue URL. Any HTML, malformed JSON, non-success HTTP response, or JSON without an issue URL falls through to the existing Firestore `reports` queue.

## Not changed
- Firestore security rules and queue schema remain unchanged.
- No public GitHub credential is introduced.
- No ingredient data, formulas, safety rules, or UI formulations are changed.

## Validation
- `pnpm check`
- `pnpm run test:issue-submission` (including the Firebase Hosting HTML-200 scenario)
- `pnpm run test:calculator`
- `pnpm build`
- Confirmed the live Firebase endpoint currently returns `HTTP 200` with `content-type: text/html` and the SPA document for unavailable `/api/submit-issue`.

## Owner review requested
Please review before approving. This PR is not merged.