### PR TITLE
fix: restore simple once-daily report queue copy

### DIFF
--- a/v3-webapp/client/src/components/IssueSubmitDialog.tsx
+++ b/v3-webapp/client/src/components/IssueSubmitDialog.tsx
@@ -111,7 +111,7 @@ export function IssueSubmitDialog({
   const successCopy = submissionMode === "created"
     ? "Your suggestion or report has been created as a tracked GitHub issue."
     : submissionMode === "queued"
-      ? "Your request has been saved to the secure review queue and will be processed into GitHub during the once-daily workflow."
+      ? "Your submission has been saved to the secure queue. It will be reviewed and converted to a GitHub issue during our once-daily processor run. You can also open it directly on GitHub immediately below."
       : "Your request is ready as a pre-filled GitHub issue. It was not submitted automatically because the in-app reporting service was unavailable.";
 
   return (
@@ -125,7 +125,7 @@ export function IssueSubmitDialog({
         <DialogHeader>
           <DialogTitle>Submit Request to Project Owner</DialogTitle>
           <DialogDescription>
-            Your report stays in the calculator. It is submitted directly when the review service is available, otherwise securely queued for the daily repository workflow.
+            Your report stays in the calculator.
           </DialogDescription>
         </DialogHeader>
 

--- a/v3-webapp/todo.md
+++ b/v3-webapp/todo.md
@@ -96,5 +96,6 @@
 - [x] Repair the GitHub Actions Firebase deployment workflow so it installs and verifies dependencies inside v3-webapp before deploying merged main.
 - [x] Adopt an issue-linked pull-request workflow with concise scope, validation, decision, and handoff comments for every substantive repository change.
 - [x] Pin third-party GitHub Actions references to full commit SHAs under GitHub Issue #56 so Dependabot validation can start under repository policy.
+- [x] Remove the unapproved implementation-detail reporting copy and restore a simple once-daily queue explanation, with exact before/after strings documented in the PR.
 - [x] Reimplement and validate the missing "Reset to standard mix" control for GitHub Issue #39 on an issue-linked review branch.
 - [x] Add automated coverage confirming profile-specific inventory presets remain distinct and resettable without shared mutation.


### PR DESCRIPTION
Closes #58

## Scope
Restores the previously approved reporting copy and removes unapproved implementation detail from the public dialog.

## Exact public-copy changes

| Location | Before | After | Rationale |
|---|---|---|---|
| Dialog description | `Your report stays in the calculator. It is submitted directly when the review service is available, otherwise securely queued for the daily repository workflow.` | `Your report stays in the calculator.` | Removes public explanation of backend-routing details. |
| Queued confirmation | `Your request has been saved to the secure review queue and will be processed into GitHub during the once-daily workflow.` | `Your submission has been saved to the secure queue. It will be reviewed and converted to a GitHub issue during our once-daily processor run. You can also open it directly on GitHub immediately below.` | Restores the earlier, clearer once-daily queue confirmation. |

## Not changed
Report submission behaviour, Firebase/Firestore security, GitHub Actions processing, labels, form fields, and all calculator data and logic remain unchanged.

## Validation
- `pnpm check`
- `pnpm run test:issue-submission`
- `pnpm build`
- Current GitHub validation and CodeQL checks passed after rebasing onto `main`.

## Owner decision
The product owner authorized merging the reviewed open pull requests in Manus chat on 17 August 2026.