### PR TITLE
fix(ci): pin GitHub Actions to immutable SHAs

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
         with:
           version: 10.4.1
           run_install: false
@@ -40,7 +40,7 @@ jobs:
           npm run build
 
       - name: Deploy to Firebase
-        uses: FirebaseExtended/action-hosting-deploy@v0
+        uses: FirebaseExtended/action-hosting-deploy@7c850a480ce753f4f06f010801fc5a43787740bb # v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_BIRD_FOOD_CALCULATOR_25E6D }}'

--- a/.github/workflows/process-reports.yml
+++ b/.github/workflows/process-reports.yml
@@ -12,10 +12,10 @@ jobs:
       issues: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out proposed change
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm

--- a/v3-webapp/todo.md
+++ b/v3-webapp/todo.md
@@ -95,5 +95,6 @@
 - [x] Add garlic oil as an occasional pigeon-only Pet/Companion recommendation through the canonical herb provenance database, without changing other bird recommendations.
 - [x] Repair the GitHub Actions Firebase deployment workflow so it installs and verifies dependencies inside v3-webapp before deploying merged main.
 - [x] Adopt an issue-linked pull-request workflow with concise scope, validation, decision, and handoff comments for every substantive repository change.
+- [x] Pin third-party GitHub Actions references to full commit SHAs under GitHub Issue #56 so Dependabot validation can start under repository policy.
 - [x] Reimplement and validate the missing "Reset to standard mix" control for GitHub Issue #39 on an issue-linked review branch.
 - [x] Add automated coverage confirming profile-specific inventory presets remain distinct and resettable without shared mutation.


### PR DESCRIPTION
Closes #56

## Scope
Pins the existing action references in validation, Firebase deployment, and report processing workflows to immutable full commit SHAs, preserving readable version comments.

## Validation
- `git diff --check` passed.
- Confirmed every `uses:` reference in `.github/workflows/` is now SHA-pinned.
- The validation commands, package versions, calculator behavior, formulations, data, and public copy are unchanged.

## Why this is needed
Dependabot PRs #52 and #53 failed before their jobs began because repository policy now blocks tag references such as `actions/checkout@v4`.

## Owner decision requested
Approve this CI-only repair. Once merged, Dependabot validation can run normally; I will then re-check #52 and #53 and merge them only if their active-V3 checks pass.