### PR TITLE
feat(herbs): show compatible birds in library

### DIFF
--- a/v3-webapp/client/src/components/HerbCard.tsx
+++ b/v3-webapp/client/src/components/HerbCard.tsx
@@ -2,15 +2,25 @@
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import type { Herb } from "@/lib/data";
-import { getHerbEvidence, HERB_SOURCES } from "@/lib/herb-evidence";
+import { getHerbEvidence, HERB_SOURCES, type HerbBirdKey } from "@/lib/herb-evidence";
+
+const birdLabels: Record<HerbBirdKey, string> = {
+  pigeon: "Pigeon",
+  parrot: "Parrot",
+  african_grey: "African Grey",
+  budgie: "Budgie",
+  canary: "Canary",
+  chicken: "Chicken",
+};
 
 interface HerbCardProps {
   name: string;
   herb: Herb;
   showSources?: boolean;
+  showCompatibleBirds?: boolean;
 }
 
-export function HerbCard({ name, herb, showSources = false }: HerbCardProps) {
+export function HerbCard({ name, herb, showSources = false, showCompatibleBirds = false }: HerbCardProps) {
   const evidence = getHerbEvidence(name);
   const sourceEntries = evidence.sourceIds.map((sourceId) => HERB_SOURCES[sourceId]);
   const safetyLabel = evidence.eligibility === "eligible"
@@ -34,6 +44,12 @@ export function HerbCard({ name, herb, showSources = false }: HerbCardProps) {
         <div className="mt-3 flex flex-wrap gap-2">
           {herb.benefits.map((benefit) => <Badge key={benefit} variant="secondary" className="bg-emerald-50 text-emerald-900 hover:bg-emerald-100">{benefit}</Badge>)}
         </div>
+        {showCompatibleBirds && <section className="mt-5" aria-label={`Compatible birds for ${name.replace(/_/g, " ")}`}>
+          <h4 className="text-sm font-semibold text-foreground">Compatible birds</h4>
+          {evidence.compatibleBirds.length ? <div className="mt-2 flex flex-wrap gap-2">
+            {evidence.compatibleBirds.map((bird) => <Badge key={bird} variant="outline" className="border-sky-200 bg-sky-50 text-sky-900">{birdLabels[bird]}</Badge>)}
+          </div> : <p className="mt-1 text-xs text-muted-foreground">No species compatibility is recorded for this reference entry.</p>}
+        </section>}
         <dl className="mt-5 space-y-3 text-sm">
           <div>
             <dt className="font-medium text-foreground">Dosage per 1 kg batch</dt>

--- a/v3-webapp/client/src/pages/HerbLibrary.tsx
+++ b/v3-webapp/client/src/pages/HerbLibrary.tsx
@@ -59,7 +59,7 @@ export default function HerbLibrary() {
                   <span className="font-mono text-sm text-muted-foreground">{herbs.length} entries</span>
                 </div>
                 <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-                  {herbs.map(([name, herb]) => <HerbCard key={name} name={name} herb={herb} showSources />)}
+                  {herbs.map(([name, herb]) => <HerbCard key={name} name={name} herb={herb} showSources showCompatibleBirds />)}
                 </div>
               </section>
             );

--- a/v3-webapp/todo.md
+++ b/v3-webapp/todo.md
@@ -103,3 +103,4 @@
 - [x] Add coverage confirming profile-default formulas exist across all six birds and actual inventory overrides the displayed default.
 - [x] Restore the exact pre-change empty-inventory message after removing unapproved explanatory public copy from the Issue #39 correction.
 - [x] Update only active V3 axios, PostCSS, and Vite patch versions for Issue #61; regenerate the locked dependency graph and preserve archive, V1/V2, Firebase Functions, and all application behavior.
+- [x] Display canonical compatible-bird badges only in the dedicated Herb Library for Issues #48 and #49, never in calculator cards.


### PR DESCRIPTION
Closes #48
Closes #49

Adds canonical compatible-bird badges only to the dedicated Herb Library. Calculator cards remain unchanged.

Visible copy added: `Compatible birds`; empty reference fallback: `No species compatibility is recorded for this reference entry.`

Validation passed: TypeScript, six-bird herb-safety verification, and production build. No formulas, herb eligibility, provenance data, sources, or public calculator copy changed.

Owner approval is required before merge.