### PR TITLE
feat: auto-label imported reports by category

### DIFF
--- a/v3-webapp/scripts/process-reports.mjs
+++ b/v3-webapp/scripts/process-reports.mjs
@@ -1,6 +1,7 @@
 import { initializeApp, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import axios from 'axios';
+import { labelsForImportedReport } from './report-labels.mjs';
 
 const serviceAccountEnv = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
 if (!serviceAccountEnv) {
@@ -42,7 +43,7 @@ async function run() {
         {
           title: data.title,
           body: `${data.body}\n\n---\n*Queued via Firestore and processed automatically.*`,
-          labels: data.labels || ["needs-research"]
+          labels: labelsForImportedReport(data.labels || ["needs-research"])
         },
         {
           headers: {

--- a/v3-webapp/scripts/report-labels.mjs
+++ b/v3-webapp/scripts/report-labels.mjs
@@ -1,0 +1,28 @@
+const PRIORITY_REPORT_LABELS = new Set(["wrong-information", "issue-report", "wrong-info"]);
+const ENHANCEMENT_REPORT_LABELS = new Set(["bird-request", "profile-request"]);
+
+/**
+ * Preserve all caller-provided labels and add the repository's existing
+ * category label exactly once. GitHub labels are case-insensitive, but we use
+ * the repository's established spelling: `Priority` and `enhancement`.
+ */
+export function labelsForImportedReport(labels = []) {
+  const existing = Array.isArray(labels) ? labels.filter(Boolean) : [];
+  const normalized = new Set(existing.map((label) => label.toLowerCase()));
+  const additions = [];
+
+  if ([...normalized].some((label) => PRIORITY_REPORT_LABELS.has(label))) {
+    if (!normalized.has("priority")) additions.push("Priority");
+  }
+
+  if ([...normalized].some((label) => ENHANCEMENT_REPORT_LABELS.has(label))) {
+    if (!normalized.has("enhancement")) additions.push("enhancement");
+  }
+
+  return [...existing, ...additions];
+}
+
+export const REPORT_LABEL_RULES = Object.freeze({
+  priority: [...PRIORITY_REPORT_LABELS],
+  enhancement: [...ENHANCEMENT_REPORT_LABELS],
+});

--- a/v3-webapp/scripts/report-labels.test.ts
+++ b/v3-webapp/scripts/report-labels.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { labelsForImportedReport } from "./report-labels.mjs";
+
+describe("labelsForImportedReport", () => {
+  it("adds Priority to wrong-information reports while preserving labels", () => {
+    expect(labelsForImportedReport(["wrong-information", "needs-research"])).toEqual([
+      "wrong-information",
+      "needs-research",
+      "Priority",
+    ]);
+  });
+
+  it("adds enhancement to bird and profile suggestions", () => {
+    expect(labelsForImportedReport(["bird-request"])).toEqual(["bird-request", "enhancement"]);
+    expect(labelsForImportedReport(["profile-request"])).toEqual(["profile-request", "enhancement"]);
+  });
+
+  it("adds both labels when a report carries both categories", () => {
+    expect(labelsForImportedReport(["issue-report", "profile-request"])).toEqual([
+      "issue-report",
+      "profile-request",
+      "Priority",
+      "enhancement",
+    ]);
+  });
+
+  it("does not duplicate labels or classify unknown reports", () => {
+    expect(labelsForImportedReport(["Priority", "enhancement", "needs-research"])).toEqual([
+      "Priority",
+      "enhancement",
+      "needs-research",
+    ]);
+    expect(labelsForImportedReport(["needs-research"])).toEqual(["needs-research"]);
+  });
+});

--- a/v3-webapp/todo.md
+++ b/v3-webapp/todo.md
@@ -104,3 +104,4 @@
 - [x] Restore the exact pre-change empty-inventory message after removing unapproved explanatory public copy from the Issue #39 correction.
 - [x] Update only active V3 axios, PostCSS, and Vite patch versions for Issue #61; regenerate the locked dependency graph and preserve archive, V1/V2, Firebase Functions, and all application behavior.
 - [x] Display canonical compatible-bird badges only in the dedicated Herb Library for Issues #48 and #49, never in calculator cards.
+- [x] Automatically add `Priority` to wrong-information/issue reports and `enhancement` to bird/profile suggestions while preserving existing imported report labels.


### PR DESCRIPTION
## Scope
Closes #77. Adds deterministic category-based labels to issues created by the daily Firestore report processor.

### Mapping
- Reports carrying `wrong-information`, `issue-report`, or `wrong-info` receive the existing `Priority` label.
- Reports carrying `bird-request` or `profile-request` receive the existing `enhancement` label.
- Existing report labels, title, and body are preserved; duplicates are not added.
- Unknown categories are unchanged.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run --root . scripts/report-labels.test.ts` — 4 tests passed
- `pnpm check` — passed
- `pnpm build` — passed

## What did not change
No Firestore schema, report body/title copy, active calculator formulas, nutrition data, safety guidance, deployment workflow, or previously processed GitHub issue was changed. The label classifier is isolated and does not reprocess existing documents.

## Owner decision requested
Please review the mapping and validation, then approve or request changes here. Do not merge until owner approval is given in Manus chat.