### PR TITLE
feat: show species-specific profile care notes

### DIFF
--- a/v3-webapp/client/src/pages/Home.tsx
+++ b/v3-webapp/client/src/pages/Home.tsx
@@ -305,8 +305,12 @@ export default function Home() {
 
                 <Separator />
                 <div className="space-y-4 text-sm">
-                  <CareNote icon={<Droplets className="h-5 w-5 text-blue-600" />} title="Water" text="Always provide clean, fresh water available at all times." />
+                  <CareNote icon={<Droplets className="h-5 w-5 text-blue-600" />} title="Water" text={care.water} />
                   <CareNote icon={<Scale className="h-5 w-5 text-amber-700" />} title="Grit" text={care.grit} />
+                  <CareNote icon={<BookOpen className="h-5 w-5 text-emerald-600" />} title="Base Diet" text={care.baseDiet} />
+                  {selectedBird === "pigeon" && (
+                    <CareNote icon={<Leaf className="h-5 w-5 text-emerald-600" />} title="Fresh Produce" text="Offer small quantities of finely chopped salad greens or grated carrots 2–3 times weekly in a separate dish." />
+                  )}
                 </div>
               </CardContent>
             </Card>

--- a/v3-webapp/todo.md
+++ b/v3-webapp/todo.md
@@ -105,3 +105,4 @@
 - [x] Update only active V3 axios, PostCSS, and Vite patch versions for Issue #61; regenerate the locked dependency graph and preserve archive, V1/V2, Firebase Functions, and all application behavior.
 - [x] Display canonical compatible-bird badges only in the dedicated Herb Library for Issues #48 and #49, never in calculator cards.
 - [x] Automatically add `Priority` to wrong-information/issue reports and `enhancement` to bird/profile suggestions while preserving existing imported report labels.
+- [x] Render canonical Water, Grit, Base Diet, and pigeon-only Fresh Produce notes together in the profile box for Issue #79.


### PR DESCRIPTION
## Scope
Closes #79.

Adds canonical species-specific care notes to the calculator profile box for all six supported birds. Water now reads from `BIRD_CARE.water`; the existing grit note remains; a new Base Diet note reads from `BIRD_CARE.baseDiet`; and pigeons receive a separate Fresh Produce note.

## Exact visible strings changed
- **Water**: previous hardcoded string `Always provide clean, fresh water available at all times.` remains the canonical pigeon/parrot/African Grey/budgie/canary wording; chicken now shows its existing canonical chicken-specific water wording.
- **Base Diet**: new visible heading `Base Diet`, populated from existing canonical `BIRD_CARE.baseDiet` values for each bird.
- **Fresh Produce**: new pigeon-only visible heading `Fresh Produce` with text: `Offer small quantities of finely chopped salad greens or grated carrots 2–3 times weekly in a separate dish.`

## What did not change
No calculation logic, formula, ingredient values, warnings, profile names, inventory behavior, or non-pigeon fresh-produce claims changed.

## Validation
- `pnpm --dir v3-webapp check`
- `pnpm --dir v3-webapp test:calculator` (21 bird/situation scenarios)
- `pnpm --dir v3-webapp build`

## Owner decision requested
Please review the preview and exact visible strings. Do not merge until the product owner approves in Manus chat.