### PR TITLE
docs(database): map historical and runtime profile targets

### DIFF
--- a/database/provenance/README.md
+++ b/database/provenance/README.md
@@ -13,7 +13,7 @@ The first ledger release is intentionally **no-runtime-change**. It preserves or
 | [`SCHEMA.md`](./SCHEMA.md) | Required shape for every future source, profile, ingredient, processing, safety, herb, and six-bird evidence row. | Governing policy. |
 | [`HISTORICAL_BASELINE.md`](./HISTORICAL_BASELINE.md) | Crosswalk to the preserved pre-GitHub project files and recovered Manus research. | Governing historical-intent index. |
 | [`food-reviews.json`](./food-reviews.json) | Future per-food, per-form, six-bird outcomes. | Empty by design until each review is evidenced. |
-| [`profile-claims.json`](./profile-claims.json) | Future profile-target provenance rows. | Empty by design until each profile range is mapped source-by-source. |
+| [`profile-claims.json`](./profile-claims.json) | Read-only historical-versus-current profile target reconciliation rows. | Seeded with configuration snapshots; scientific reconciliation remains pending. |
 
 ## Non-negotiable rules
 
@@ -64,5 +64,7 @@ The first ledger release is intentionally **no-runtime-change**. It preserves or
 | `merck-poultry-2024` | Chicken nutrition requirements | Peer-reviewed veterinary reference |
 | `nas-poultry-2026` | Chicken nutrition book | National Academies consensus report |
 | `clinical-avian-medicine-2006` | Cross-species nutrition, toxicology, pigeon, galliform, and canary/finch chapters | Academic veterinary book |
+| `historical-preaudit-profile-config` | Preserved pre-audit multi-bird profile configuration | Historical project configuration |
+| `runtime-v3-profile-config` | Current V3 `birds.ts` profile configuration | Runtime configuration snapshot |
 
 The detailed machine-readable entries, scopes, URLs, and limitations are in [`sources.json`](./sources.json).

--- a/database/provenance/SCHEMA.md
+++ b/database/provenance/SCHEMA.md
@@ -10,7 +10,7 @@ Every reusable source is defined once in `sources.json`.
 | `title` | Yes | Source title. |
 | `authorsOrOrganization` | Yes | Named authors or responsible organization. |
 | `publishedYear` | Yes | Publication/update year; `unknown` is permitted only for protected historical project files. |
-| `sourceTier` | Yes | `primary`, `systematic_review`, `peer_reviewed_review`, `veterinary_reference`, `academic_book`, `owner_guidance_with_citations`, or `historical_project`. |
+| `sourceTier` | Yes | `primary`, `systematic_review`, `peer_reviewed_review`, `veterinary_reference`, `academic_book`, `owner_guidance_with_citations`, `historical_project`, or `runtime_configuration`. |
 | `urlOrDoi` | Yes | Stable public URL or DOI; repository-relative path for protected project evidence. |
 | `speciesScopes` | Yes | Species or species groups the source actually covers. |
 | `permittedUse` | Yes | What the source can substantiate. |
@@ -64,9 +64,9 @@ Every reusable source is defined once in `sources.json`.
 
 ## Profile claim record
 
-`profile-claims.json` will contain `profileClaims`. Each profile range must list its exact bird, profile name, nutrient, numeric range, source IDs, locator, evidence scope, and historical-to-active reconciliation status.
+`profile-claims.json` contains `profileClaims`. Each profile range lists its exact bird, profile name, nutrient, numeric range, source IDs, locator, evidence scope, claim kind, linked counterpart, and historical-to-active reconciliation status.
 
-The ledger does not decide which historical or current target is correct. It records their sources and differences so the owner can approve a later runtime decision.
+`claimKind` is either `protected_historical_configuration` or `runtime_configuration_snapshot`. `reconciliationStatus` is either `matches_pre_audit_configuration` or `differs_from_pre_audit_configuration`. A configuration snapshot is evidence of what the app used, **not** scientific validation of the range. The ledger does not decide which historical or current target is correct; it records their sources and differences so the owner can approve a later runtime decision.
 
 ## Historical claim record
 

--- a/database/provenance/profile-claims.json
+++ b/database/provenance/profile-claims.json
@@ -1,5 +1,3534 @@
 {
   "schemaVersion": 1,
-  "purpose": "Future source-level reconciliation records for active and historical profile targets. This first no-runtime-change ledger release intentionally seeds no runtime target decision.",
-  "profileClaims": []
+  "purpose": "Read-only reconciliation records for preserved pre-audit profile configuration and current V3 runtime configuration. A record is not a scientific endorsement or runtime adapter.",
+  "profileClaims": [
+    {
+      "id": "profile.pigeon.maintenance.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "maintenance",
+      "profileName": "Maintenance/Rest",
+      "nutrient": "protein",
+      "range": [
+        13.5,
+        15
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.maintenance.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.maintenance.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.maintenance.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "maintenance",
+      "profileName": "Maintenance/Rest",
+      "nutrient": "protein",
+      "range": [
+        13.5,
+        15
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.maintenance.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.maintenance.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.maintenance.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "maintenance",
+      "profileName": "Maintenance/Rest",
+      "nutrient": "carbs",
+      "range": [
+        60,
+        70
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.maintenance.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.maintenance.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.maintenance.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "maintenance",
+      "profileName": "Maintenance/Rest",
+      "nutrient": "carbs",
+      "range": [
+        60,
+        70
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.maintenance.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.maintenance.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.maintenance.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "maintenance",
+      "profileName": "Maintenance/Rest",
+      "nutrient": "fat",
+      "range": [
+        2.5,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.maintenance.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.maintenance.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.maintenance.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "maintenance",
+      "profileName": "Maintenance/Rest",
+      "nutrient": "fat",
+      "range": [
+        2.5,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.maintenance.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.maintenance.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.maintenance.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "maintenance",
+      "profileName": "Maintenance/Rest",
+      "nutrient": "fiber",
+      "range": [
+        0.5,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.maintenance.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.maintenance.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.maintenance.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "maintenance",
+      "profileName": "Maintenance/Rest",
+      "nutrient": "fiber",
+      "range": [
+        0.5,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.maintenance.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.maintenance.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.racing.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "racing",
+      "profileName": "Racing/Competition",
+      "nutrient": "protein",
+      "range": [
+        16,
+        18
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.racing.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.racing.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.racing.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "racing",
+      "profileName": "Racing/Competition",
+      "nutrient": "protein",
+      "range": [
+        16,
+        18
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.racing.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.racing.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.racing.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "racing",
+      "profileName": "Racing/Competition",
+      "nutrient": "carbs",
+      "range": [
+        58,
+        68
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.racing.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.racing.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.racing.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "racing",
+      "profileName": "Racing/Competition",
+      "nutrient": "carbs",
+      "range": [
+        55,
+        65
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.racing.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.racing.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.racing.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "racing",
+      "profileName": "Racing/Competition",
+      "nutrient": "fat",
+      "range": [
+        4,
+        6
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.racing.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.racing.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.racing.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "racing",
+      "profileName": "Racing/Competition",
+      "nutrient": "fat",
+      "range": [
+        3,
+        5
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.racing.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.racing.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.racing.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "racing",
+      "profileName": "Racing/Competition",
+      "nutrient": "fiber",
+      "range": [
+        0.5,
+        1.5
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.racing.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.racing.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.racing.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "racing",
+      "profileName": "Racing/Competition",
+      "nutrient": "fiber",
+      "range": [
+        0.5,
+        1.5
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.racing.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.racing.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.breeding.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "breeding",
+      "profileName": "Breeding/Brooding",
+      "nutrient": "protein",
+      "range": [
+        14,
+        16
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.breeding.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.breeding.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.breeding.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "protein",
+      "range": [
+        14,
+        16
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.breeding.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.breeding.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.breeding.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "breeding",
+      "profileName": "Breeding/Brooding",
+      "nutrient": "carbs",
+      "range": [
+        60,
+        68
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.breeding.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.breeding.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.breeding.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "carbs",
+      "range": [
+        58,
+        68
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.breeding.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.breeding.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.breeding.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "breeding",
+      "profileName": "Breeding/Brooding",
+      "nutrient": "fat",
+      "range": [
+        3,
+        5
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.breeding.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.breeding.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.breeding.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "fat",
+      "range": [
+        3,
+        4.5
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.breeding.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.breeding.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.breeding.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "breeding",
+      "profileName": "Breeding/Brooding",
+      "nutrient": "fiber",
+      "range": [
+        0.5,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.breeding.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.breeding.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.breeding.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "fiber",
+      "range": [
+        0.5,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.breeding.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.breeding.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.molting.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "protein",
+      "range": [
+        16,
+        18
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.molting.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.molting.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.molting.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "protein",
+      "range": [
+        16,
+        18
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.molting.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.molting.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.molting.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "carbs",
+      "range": [
+        58,
+        68
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.molting.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.molting.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.molting.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "carbs",
+      "range": [
+        55,
+        65
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.molting.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.molting.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.molting.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fat",
+      "range": [
+        4,
+        6
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.molting.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.molting.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.molting.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fat",
+      "range": [
+        3.5,
+        5
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.molting.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.molting.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.molting.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fiber",
+      "range": [
+        0.5,
+        1.5
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.molting.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.molting.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.molting.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fiber",
+      "range": [
+        0.5,
+        1.5
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.molting.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.molting.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.winter.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "winter",
+      "profileName": "Winter Season",
+      "nutrient": "protein",
+      "range": [
+        12,
+        14
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.winter.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.winter.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.winter.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "winter",
+      "profileName": "Winter Season",
+      "nutrient": "protein",
+      "range": [
+        12,
+        14
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.winter.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.winter.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.winter.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "winter",
+      "profileName": "Winter Season",
+      "nutrient": "carbs",
+      "range": [
+        62,
+        72
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.winter.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.winter.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.winter.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "winter",
+      "profileName": "Winter Season",
+      "nutrient": "carbs",
+      "range": [
+        55,
+        65
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.winter.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.winter.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.winter.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "winter",
+      "profileName": "Winter Season",
+      "nutrient": "fat",
+      "range": [
+        5,
+        8
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.winter.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.winter.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.winter.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "winter",
+      "profileName": "Winter Season",
+      "nutrient": "fat",
+      "range": [
+        4,
+        6
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.winter.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.winter.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.winter.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "winter",
+      "profileName": "Winter Season",
+      "nutrient": "fiber",
+      "range": [
+        0.5,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.winter.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.winter.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.winter.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "winter",
+      "profileName": "Winter Season",
+      "nutrient": "fiber",
+      "range": [
+        0.5,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.winter.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.winter.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.pet.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "protein",
+      "range": [
+        12,
+        14
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.pet.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.pet.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.pet.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "protein",
+      "range": [
+        12,
+        14
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.pet.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.pet.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.pet.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "carbs",
+      "range": [
+        62,
+        70
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.pet.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.pet.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.pet.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "carbs",
+      "range": [
+        60,
+        70
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.pet.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.pet.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.pet.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fat",
+      "range": [
+        2.5,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.pet.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.pet.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.pet.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fat",
+      "range": [
+        2.5,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.pet.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.pet.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.pet.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "pigeon",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fiber",
+      "range": [
+        0.5,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.pigeon.pet.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.pet.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.pigeon.pet.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "pigeon",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fiber",
+      "range": [
+        1,
+        2.5
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.pigeon.profiles.pet.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.pigeon.pet.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.pet.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "parrot",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "protein",
+      "range": [
+        10,
+        12
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.parrot.pet.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.pet.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.pet.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "parrot",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "protein",
+      "range": [
+        10,
+        15
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.parrot.profiles.pet.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.pet.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.pet.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "parrot",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "carbs",
+      "range": [
+        60,
+        70
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.parrot.pet.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.pet.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.pet.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "parrot",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "carbs",
+      "range": [
+        50,
+        65
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.parrot.profiles.pet.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.pet.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.pet.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "parrot",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fat",
+      "range": [
+        5,
+        8
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.parrot.pet.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.pet.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.pet.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "parrot",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fat",
+      "range": [
+        5,
+        12
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.parrot.profiles.pet.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.pet.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.pet.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "parrot",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fiber",
+      "range": [
+        1,
+        3
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.parrot.pet.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.pet.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.pet.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "parrot",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fiber",
+      "range": [
+        2,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.parrot.profiles.pet.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.pet.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.breeding.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "parrot",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "protein",
+      "range": [
+        14,
+        16
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.parrot.breeding.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.breeding.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.breeding.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "parrot",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "protein",
+      "range": [
+        12,
+        16
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.parrot.profiles.breeding.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.breeding.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.breeding.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "parrot",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "carbs",
+      "range": [
+        58,
+        68
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.parrot.breeding.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.breeding.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.breeding.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "parrot",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "carbs",
+      "range": [
+        48,
+        62
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.parrot.profiles.breeding.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.breeding.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.breeding.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "parrot",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "fat",
+      "range": [
+        6,
+        10
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.parrot.breeding.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.breeding.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.breeding.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "parrot",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "fat",
+      "range": [
+        6,
+        12
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.parrot.profiles.breeding.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.breeding.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.breeding.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "parrot",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "fiber",
+      "range": [
+        1,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.parrot.breeding.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.breeding.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.breeding.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "parrot",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "fiber",
+      "range": [
+        2,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.parrot.profiles.breeding.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.breeding.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.molting.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "parrot",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "protein",
+      "range": [
+        14,
+        16
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.parrot.molting.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.molting.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.molting.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "parrot",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "protein",
+      "range": [
+        14,
+        18
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.parrot.profiles.molting.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.molting.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.molting.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "parrot",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "carbs",
+      "range": [
+        58,
+        68
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.parrot.molting.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.molting.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.molting.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "parrot",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "carbs",
+      "range": [
+        45,
+        60
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.parrot.profiles.molting.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.molting.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.molting.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "parrot",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fat",
+      "range": [
+        6,
+        9
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.parrot.molting.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.molting.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.molting.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "parrot",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fat",
+      "range": [
+        6,
+        12
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.parrot.profiles.molting.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.molting.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.molting.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "parrot",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fiber",
+      "range": [
+        1,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.parrot.molting.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.molting.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.parrot.molting.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "parrot",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fiber",
+      "range": [
+        2,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.parrot.profiles.molting.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.parrot.molting.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.pet.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "african_grey",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "protein",
+      "range": [
+        12,
+        14
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.african_grey.pet.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.pet.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.pet.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "african_grey",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "protein",
+      "range": [
+        10,
+        14
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.african_grey.profiles.pet.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.pet.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.pet.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "african_grey",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "carbs",
+      "range": [
+        58,
+        68
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.african_grey.pet.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.pet.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.pet.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "african_grey",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "carbs",
+      "range": [
+        50,
+        65
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.african_grey.profiles.pet.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.pet.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.pet.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "african_grey",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fat",
+      "range": [
+        6,
+        9
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.african_grey.pet.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.pet.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.pet.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "african_grey",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fat",
+      "range": [
+        5,
+        10
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.african_grey.profiles.pet.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.pet.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.pet.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "african_grey",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fiber",
+      "range": [
+        1,
+        3
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.african_grey.pet.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.pet.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.pet.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "african_grey",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fiber",
+      "range": [
+        2,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.african_grey.profiles.pet.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.pet.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.breeding.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "african_grey",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "protein",
+      "range": [
+        15,
+        17
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.african_grey.breeding.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.breeding.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.breeding.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "african_grey",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "protein",
+      "range": [
+        12,
+        15
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.african_grey.profiles.breeding.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.breeding.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.breeding.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "african_grey",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "carbs",
+      "range": [
+        56,
+        66
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.african_grey.breeding.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.breeding.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.breeding.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "african_grey",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "carbs",
+      "range": [
+        48,
+        62
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.african_grey.profiles.breeding.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.breeding.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.breeding.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "african_grey",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "fat",
+      "range": [
+        7,
+        11
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.african_grey.breeding.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.breeding.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.breeding.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "african_grey",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "fat",
+      "range": [
+        6,
+        10
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.african_grey.profiles.breeding.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.breeding.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.breeding.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "african_grey",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "fiber",
+      "range": [
+        1,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.african_grey.breeding.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.breeding.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.breeding.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "african_grey",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "fiber",
+      "range": [
+        2,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.african_grey.profiles.breeding.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.breeding.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.molting.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "african_grey",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "protein",
+      "range": [
+        15,
+        17
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.african_grey.molting.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.molting.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.molting.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "african_grey",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "protein",
+      "range": [
+        13,
+        16
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.african_grey.profiles.molting.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.molting.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.molting.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "african_grey",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "carbs",
+      "range": [
+        56,
+        66
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.african_grey.molting.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.molting.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.molting.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "african_grey",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "carbs",
+      "range": [
+        45,
+        60
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.african_grey.profiles.molting.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.molting.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.molting.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "african_grey",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fat",
+      "range": [
+        7,
+        10
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.african_grey.molting.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.molting.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.molting.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "african_grey",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fat",
+      "range": [
+        6,
+        10
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.african_grey.profiles.molting.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.molting.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.molting.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "african_grey",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fiber",
+      "range": [
+        1,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.african_grey.molting.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.molting.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.african_grey.molting.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "african_grey",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fiber",
+      "range": [
+        2,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.african_grey.profiles.molting.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.african_grey.molting.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.pet.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "budgie",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "protein",
+      "range": [
+        11,
+        13
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.budgie.pet.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.pet.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.pet.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "budgie",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "protein",
+      "range": [
+        12,
+        14
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.budgie.profiles.pet.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.pet.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.pet.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "budgie",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "carbs",
+      "range": [
+        62,
+        72
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.budgie.pet.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.pet.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.pet.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "budgie",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "carbs",
+      "range": [
+        55,
+        70
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.budgie.profiles.pet.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.pet.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.pet.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "budgie",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fat",
+      "range": [
+        7,
+        10
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.budgie.pet.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.pet.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.pet.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "budgie",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fat",
+      "range": [
+        5,
+        10
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.budgie.profiles.pet.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.pet.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.pet.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "budgie",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fiber",
+      "range": [
+        1,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.budgie.pet.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.pet.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.pet.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "budgie",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fiber",
+      "range": [
+        2,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.budgie.profiles.pet.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.pet.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.breeding.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "budgie",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "protein",
+      "range": [
+        13,
+        15
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.budgie.breeding.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.breeding.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.breeding.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "budgie",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "protein",
+      "range": [
+        14,
+        16
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.budgie.profiles.breeding.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.breeding.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.breeding.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "budgie",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "carbs",
+      "range": [
+        60,
+        70
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.budgie.breeding.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.breeding.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.breeding.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "budgie",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "carbs",
+      "range": [
+        50,
+        65
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.budgie.profiles.breeding.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.breeding.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.breeding.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "budgie",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "fat",
+      "range": [
+        8,
+        12
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.budgie.breeding.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.breeding.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.breeding.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "budgie",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "fat",
+      "range": [
+        6,
+        10
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.budgie.profiles.breeding.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.breeding.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.breeding.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "budgie",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "fiber",
+      "range": [
+        1,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.budgie.breeding.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.breeding.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.breeding.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "budgie",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "fiber",
+      "range": [
+        2,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.budgie.profiles.breeding.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.breeding.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.molting.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "budgie",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "protein",
+      "range": [
+        13,
+        15
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.budgie.molting.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.molting.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.molting.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "budgie",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "protein",
+      "range": [
+        15,
+        17
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.budgie.profiles.molting.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.molting.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.molting.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "budgie",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "carbs",
+      "range": [
+        60,
+        70
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.budgie.molting.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.molting.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.molting.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "budgie",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "carbs",
+      "range": [
+        48,
+        62
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.budgie.profiles.molting.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.molting.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.molting.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "budgie",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fat",
+      "range": [
+        8,
+        11
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.budgie.molting.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.molting.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.molting.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "budgie",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fat",
+      "range": [
+        6,
+        10
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.budgie.profiles.molting.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.molting.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.molting.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "budgie",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fiber",
+      "range": [
+        1,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.budgie.molting.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.molting.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.budgie.molting.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "budgie",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fiber",
+      "range": [
+        2,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.budgie.profiles.molting.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.budgie.molting.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.pet.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "canary",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "protein",
+      "range": [
+        12,
+        14
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.canary.pet.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.pet.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.pet.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "canary",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "protein",
+      "range": [
+        12,
+        14
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.canary.profiles.pet.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.pet.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.pet.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "canary",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "carbs",
+      "range": [
+        64,
+        74
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.canary.pet.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.pet.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.pet.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "canary",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "carbs",
+      "range": [
+        60,
+        72
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.canary.profiles.pet.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.pet.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.pet.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "canary",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fat",
+      "range": [
+        8,
+        11
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.canary.pet.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.pet.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.pet.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "canary",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fat",
+      "range": [
+        4,
+        8
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.canary.profiles.pet.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.pet.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.pet.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "canary",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fiber",
+      "range": [
+        1,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.canary.pet.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.pet.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.pet.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "canary",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fiber",
+      "range": [
+        2,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.canary.profiles.pet.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.pet.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.breeding.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "canary",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "protein",
+      "range": [
+        14,
+        16
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.canary.breeding.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.breeding.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.breeding.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "canary",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "protein",
+      "range": [
+        14,
+        16
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.canary.profiles.breeding.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.breeding.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.breeding.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "canary",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "carbs",
+      "range": [
+        62,
+        72
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.canary.breeding.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.breeding.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.breeding.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "canary",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "carbs",
+      "range": [
+        55,
+        68
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.canary.profiles.breeding.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.breeding.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.breeding.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "canary",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "fat",
+      "range": [
+        9,
+        13
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.canary.breeding.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.breeding.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.breeding.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "canary",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "fat",
+      "range": [
+        5,
+        9
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.canary.profiles.breeding.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.breeding.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.breeding.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "canary",
+      "profile": "breeding",
+      "profileName": "Breeding/Egg-laying",
+      "nutrient": "fiber",
+      "range": [
+        1,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.canary.breeding.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.breeding.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.breeding.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "canary",
+      "profile": "breeding",
+      "profileName": "Breeding",
+      "nutrient": "fiber",
+      "range": [
+        2,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.canary.profiles.breeding.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.breeding.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.molting.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "canary",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "protein",
+      "range": [
+        14,
+        16
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.canary.molting.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.molting.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.molting.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "canary",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "protein",
+      "range": [
+        15,
+        17
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.canary.profiles.molting.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.molting.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.molting.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "canary",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "carbs",
+      "range": [
+        62,
+        72
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.canary.molting.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.molting.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.molting.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "canary",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "carbs",
+      "range": [
+        52,
+        65
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.canary.profiles.molting.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.molting.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.molting.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "canary",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fat",
+      "range": [
+        9,
+        12
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.canary.molting.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.molting.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.molting.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "canary",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fat",
+      "range": [
+        5,
+        9
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.canary.profiles.molting.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.molting.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.molting.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "canary",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fiber",
+      "range": [
+        1,
+        2
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.canary.molting.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.molting.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.canary.molting.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "canary",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fiber",
+      "range": [
+        2,
+        4
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.canary.profiles.molting.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.canary.molting.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.pet.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "chicken",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "protein",
+      "range": [
+        14,
+        16
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.chicken.pet.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.pet.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.pet.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "chicken",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "protein",
+      "range": [
+        12,
+        16
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.chicken.profiles.pet.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.pet.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.pet.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "chicken",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "carbs",
+      "range": [
+        58,
+        68
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.chicken.pet.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.pet.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.pet.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "chicken",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "carbs",
+      "range": [
+        55,
+        70
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.chicken.profiles.pet.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.pet.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.pet.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "chicken",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fat",
+      "range": [
+        4,
+        7
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.chicken.pet.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.pet.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.pet.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "chicken",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fat",
+      "range": [
+        3,
+        6
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.chicken.profiles.pet.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.pet.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.pet.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "chicken",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fiber",
+      "range": [
+        3,
+        6
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.chicken.pet.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.pet.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.pet.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "chicken",
+      "profile": "pet",
+      "profileName": "Pet/Companion",
+      "nutrient": "fiber",
+      "range": [
+        3,
+        5
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.chicken.profiles.pet.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.pet.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.egg_laying.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "chicken",
+      "profile": "egg_laying",
+      "profileName": "Egg-laying",
+      "nutrient": "protein",
+      "range": [
+        16,
+        18
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.chicken.egg-laying.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.egg_laying.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.egg_laying.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "chicken",
+      "profile": "egg_laying",
+      "profileName": "Egg-laying",
+      "nutrient": "protein",
+      "range": [
+        16,
+        18
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.chicken.profiles.egg_laying.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "matches_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.egg_laying.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.egg_laying.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "chicken",
+      "profile": "egg_laying",
+      "profileName": "Egg-laying",
+      "nutrient": "carbs",
+      "range": [
+        56,
+        66
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.chicken.egg-laying.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.egg_laying.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.egg_laying.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "chicken",
+      "profile": "egg_laying",
+      "profileName": "Egg-laying",
+      "nutrient": "carbs",
+      "range": [
+        50,
+        65
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.chicken.profiles.egg_laying.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.egg_laying.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.egg_laying.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "chicken",
+      "profile": "egg_laying",
+      "profileName": "Egg-laying",
+      "nutrient": "fat",
+      "range": [
+        5,
+        8
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.chicken.egg-laying.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.egg_laying.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.egg_laying.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "chicken",
+      "profile": "egg_laying",
+      "profileName": "Egg-laying",
+      "nutrient": "fat",
+      "range": [
+        4,
+        7
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.chicken.profiles.egg_laying.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.egg_laying.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.egg_laying.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "chicken",
+      "profile": "egg_laying",
+      "profileName": "Egg-laying",
+      "nutrient": "fiber",
+      "range": [
+        3,
+        6
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.chicken.egg-laying.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.egg_laying.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.egg_laying.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "chicken",
+      "profile": "egg_laying",
+      "profileName": "Egg-laying",
+      "nutrient": "fiber",
+      "range": [
+        3,
+        5
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.chicken.profiles.egg_laying.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.egg_laying.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.molting.protein.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "chicken",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "protein",
+      "range": [
+        17,
+        19
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.chicken.molting.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.molting.protein.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.molting.protein.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "chicken",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "protein",
+      "range": [
+        16,
+        18
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.chicken.profiles.molting.nutrition.protein",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.molting.protein.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.molting.carbs.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "chicken",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "carbs",
+      "range": [
+        54,
+        64
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.chicken.molting.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.molting.carbs.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.molting.carbs.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "chicken",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "carbs",
+      "range": [
+        50,
+        65
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.chicken.profiles.molting.nutrition.carbs",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.molting.carbs.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.molting.fat.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "chicken",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fat",
+      "range": [
+        5,
+        8
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.chicken.molting.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.molting.fat.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.molting.fat.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "chicken",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fat",
+      "range": [
+        4,
+        7
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.chicken.profiles.molting.nutrition.fat",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.molting.fat.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.molting.fiber.historical_configuration",
+      "claimKind": "protected_historical_configuration",
+      "bird": "chicken",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fiber",
+      "range": [
+        3,
+        6
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "historical-preaudit-profile-config"
+      ],
+      "locator": "client/src/lib/birds.ts → ALL_PROFILES.chicken.molting.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.molting.fiber.runtime_configuration",
+      "reviewedAt": "2026-08-17"
+    },
+    {
+      "id": "profile.chicken.molting.fiber.runtime_configuration",
+      "claimKind": "runtime_configuration_snapshot",
+      "bird": "chicken",
+      "profile": "molting",
+      "profileName": "Molting Season",
+      "nutrient": "fiber",
+      "range": [
+        3,
+        5
+      ],
+      "unit": "percent_of_dry_seed_grain_batch_estimate",
+      "sourceIds": [
+        "runtime-v3-profile-config"
+      ],
+      "locator": "v3-webapp/client/src/lib/birds.ts → BIRD_PROFILES.chicken.profiles.molting.nutrition.fiber",
+      "evidenceScope": "historical_project",
+      "reconciliationStatus": "differs_from_pre_audit_configuration",
+      "comparedClaimId": "profile.chicken.molting.fiber.historical_configuration",
+      "reviewedAt": "2026-08-17"
+    }
+  ]
 }

--- a/database/provenance/sources.json
+++ b/database/provenance/sources.json
@@ -156,6 +156,30 @@
       "permittedUse": "Cross-species chapter-level veterinary reference for nutrition, toxicology, racing pigeons, galliformes, and canaries/finches.",
       "limitations": "Each future claim must cite its exact relevant chapter/section; the book title cannot act as blanket six-bird approval.",
       "accessedAt": "2026-08-17"
+    },
+    {
+      "id": "historical-preaudit-profile-config",
+      "title": "Preserved pre-audit multi-bird profile configuration",
+      "authorsOrOrganization": "Original Manus project implementation",
+      "publishedYear": "2025",
+      "sourceTier": "historical_project",
+      "urlOrDoi": "Preserved Manus archive: pigeon-mix-web-multi-bird/client/src/lib/birds.ts",
+      "speciesScopes": ["pigeon", "parrot", "african_grey", "budgie", "canary", "chicken"],
+      "permittedUse": "Exact preservation of the pre-audit multi-bird profile configuration used for reconciliation.",
+      "limitations": "This configuration snapshot proves the previous implemented value; it is not a scientific source validating that value.",
+      "accessedAt": "2026-08-17"
+    },
+    {
+      "id": "runtime-v3-profile-config",
+      "title": "Current V3 runtime profile configuration",
+      "authorsOrOrganization": "Bird Feed Calculator V3 implementation",
+      "publishedYear": "2026",
+      "sourceTier": "runtime_configuration",
+      "urlOrDoi": "v3-webapp/client/src/lib/birds.ts",
+      "speciesScopes": ["pigeon", "parrot", "african_grey", "budgie", "canary", "chicken"],
+      "permittedUse": "Exact snapshot of the currently configured V3 target ranges for reconciliation only.",
+      "limitations": "This is a live implementation snapshot, not a scientific source or a replacement for the protected original research.",
+      "accessedAt": "2026-08-17"
     }
   ]
 }

--- a/database/tools/validate-provenance-ledger.mjs
+++ b/database/tools/validate-provenance-ledger.mjs
@@ -21,6 +21,7 @@ const sourceTiers = new Set([
   "academic_book",
   "owner_guidance_with_citations",
   "historical_project",
+  "runtime_configuration",
 ]);
 
 const outcomes = new Set([
@@ -37,6 +38,16 @@ const evidenceScopes = new Set([
   "group_specific",
   "related_species",
   "historical_project",
+]);
+
+const profileClaimKinds = new Set([
+  "protected_historical_configuration",
+  "runtime_configuration_snapshot",
+]);
+
+const profileReconciliationStatuses = new Set([
+  "matches_pre_audit_configuration",
+  "differs_from_pre_audit_configuration",
 ]);
 
 function readJson(fileName) {
@@ -149,17 +160,52 @@ function validateFoodReviews(reviews, sourceIndex, errors) {
 }
 
 function validateProfileClaims(claims, sourceIndex, errors) {
+  const claimIndex = new Map();
+
   for (const claim of claims) {
     const context = `Profile claim '${claim.id ?? "<missing id>"}'`;
-    for (const field of ["id", "bird", "profile", "nutrient", "locator", "evidenceScope", "reviewedAt"]) {
+    for (const field of ["id", "claimKind", "bird", "profile", "profileName", "nutrient", "unit", "locator", "evidenceScope", "reconciliationStatus", "comparedClaimId", "reviewedAt"]) {
       if (!isNonEmptyString(claim[field])) {
         errors.push(`${context} must include '${field}'.`);
       }
     }
+
+    if (claimIndex.has(claim.id)) {
+      errors.push(`${context} has a duplicated ID.`);
+    }
+    claimIndex.set(claim.id, claim);
+
+    if (!profileClaimKinds.has(claim.claimKind)) {
+      errors.push(`${context} has unsupported claim kind '${claim.claimKind}'.`);
+    }
     if (!evidenceScopes.has(claim.evidenceScope)) {
       errors.push(`${context} has unsupported evidence scope '${claim.evidenceScope}'.`);
     }
+    if (!profileReconciliationStatuses.has(claim.reconciliationStatus)) {
+      errors.push(`${context} has unsupported reconciliation status '${claim.reconciliationStatus}'.`);
+    }
+    if (!Array.isArray(claim.range) || claim.range.length !== 2 || !claim.range.every((value) => typeof value === "number")) {
+      errors.push(`${context} must include a two-value numeric range.`);
+    }
     validateSourceReferences(claim.sourceIds, sourceIndex, context, errors);
+  }
+
+  for (const claim of claims) {
+    const counterpart = claimIndex.get(claim.comparedClaimId);
+    const context = `Profile claim '${claim.id ?? "<missing id>"}'`;
+    if (!counterpart) {
+      errors.push(`${context} must point to an existing paired claim.`);
+      continue;
+    }
+    if (counterpart.comparedClaimId !== claim.id) {
+      errors.push(`${context} must be reciprocally linked to its paired claim.`);
+    }
+    if (counterpart.bird !== claim.bird || counterpart.profile !== claim.profile || counterpart.nutrient !== claim.nutrient) {
+      errors.push(`${context} must pair with the same bird, profile, and nutrient.`);
+    }
+    if (counterpart.reconciliationStatus !== claim.reconciliationStatus) {
+      errors.push(`${context} and its paired claim must share a reconciliation status.`);
+    }
   }
 }
 

--- a/v3-webapp/client/src/lib/provenance-ledger.test.ts
+++ b/v3-webapp/client/src/lib/provenance-ledger.test.ts
@@ -45,4 +45,27 @@ describe("canonical provenance ledger", () => {
       "chicken",
     ]);
   });
+
+  it("keeps protected and runtime profile configuration claims paired without deciding which range is scientifically correct", () => {
+    const ledger = readJson("profile-claims.json") as {
+      profileClaims: Array<{
+        id: string;
+        claimKind: string;
+        comparedClaimId: string;
+        reconciliationStatus: string;
+      }>;
+    };
+    const claimsById = new Map(ledger.profileClaims.map((claim) => [claim.id, claim]));
+
+    expect(ledger.profileClaims).toHaveLength(168);
+    expect(ledger.profileClaims.filter((claim) => claim.claimKind === "protected_historical_configuration")).toHaveLength(84);
+    expect(ledger.profileClaims.filter((claim) => claim.claimKind === "runtime_configuration_snapshot")).toHaveLength(84);
+
+    for (const claim of ledger.profileClaims) {
+      const counterpart = claimsById.get(claim.comparedClaimId);
+      expect(counterpart).toBeDefined();
+      expect(counterpart?.comparedClaimId).toBe(claim.id);
+      expect(counterpart?.reconciliationStatus).toBe(claim.reconciliationStatus);
+    }
+  });
 });


### PR DESCRIPTION
Depends on #88 and addresses #89.

## Scope

This no-runtime-change PR populates the new provenance ledger with an exact, paired map of the preserved pre-audit multi-bird profile configuration and the current V3 runtime profile configuration.

It records **168 profile claims**: 84 protected historical configuration rows and 84 current runtime configuration rows. Each pair covers one bird/profile/macronutrient target and is linked with a reconciliation status of either `matches_pre_audit_configuration` or `differs_from_pre_audit_configuration`.

## What this records

| Item | Treatment |
|---|---|
| Historical target | Preserved as a configuration snapshot from the pre-audit multi-bird source. |
| Current V3 target | Preserved as a runtime configuration snapshot from `v3-webapp/client/src/lib/birds.ts`. |
| Scientific status | Explicitly **not decided** by this PR. A configuration snapshot proves what was used, not whether it is scientifically correct. |
| Discrepancies | Recorded transparently rather than resolved by changing a target. |

## Validation

| Check | Result |
|---|---|
| `pnpm test:provenance` | Passed: 15 sources, 3 protected historical claims, 168 paired profile claims, 4 Vitest tests. |
| `pnpm check` | Passed. |
| `pnpm test:calculator` | Passed: existing 21 bird/situation scenarios. |
| `pnpm build` | Passed. Existing bundle-size warning unchanged. |

## What did not change

No runtime target, formula, category allocation, ingredient value, compatibility outcome, safety outcome, warning, herb recommendation, inventory behavior, public copy, icon, Firebase setting, or deployment behavior changed.

There are **no public-facing strings changed** in this PR.

## Owner decision requested

Please review the mapping model: storing historical and current values side by side, explicitly labelling 67 differing runtime range rows, and leaving scientific reconciliation unresolved until each source is mapped at the claim level. I will not merge this PR, change a live profile target, or interpret a discrepancy as an error without your approval.
