### PR TITLE
fix(care): clarify diet and breeding grit guidance

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Verify all calculator scenarios
         run: pnpm --dir v3-webapp test:calculator
 
+      - name: Verify care guidance
+        run: pnpm --dir v3-webapp test:care-guidance
+
       - name: Validate provenance ledger
         run: pnpm test:provenance
 

--- a/v3-webapp/client/src/lib/birds.ts
+++ b/v3-webapp/client/src/lib/birds.ts
@@ -35,6 +35,7 @@ export interface BirdCareGuidance {
   baseDiet: string;
   water: string;
   grit: string;
+  gritBySituation?: Partial<Record<string, string>>;
 }
 
 export const BIRD_PROFILES: Record<BirdType, BirdProfile> = {
@@ -351,37 +352,40 @@ export const DEFAULT_CATEGORY_TARGETS: Record<BirdType, CategoryTargets> = {
 export const BIRD_CARE: Record<BirdType, BirdCareGuidance> = {
   pigeon: {
     scope: 'A batch estimate for a pigeon seed and grain mix; it does not assess vitamins, minerals, amino acids, or energy density.',
-    baseDiet: 'Use a balanced pigeon diet with fresh produce and seek a review from an exotics vet for performance, breeding, or health concerns.',
+    baseDiet: 'Use a balanced pigeon diet with fresh produce.',
     water: 'Always provide clean, fresh water available at all times.',
     grit: 'Pigeons need grit to properly digest seeds and grains.',
+    gritBySituation: {
+      breeding: 'During breeding, include suitable shell grit as a calcium source.',
+    },
   },
   parrot: {
     scope: 'A seed and grain enrichment mix, not a complete parrot diet.',
-    baseDiet: 'Use a species-appropriate formulated diet as the nutritional base, with fresh vegetables and only limited seeds or nuts.',
+    baseDiet: 'Use a species-appropriate formulated diet as the nutritional base, with fresh vegetables and fruit, and only limited seeds or nuts.',
     water: 'Always provide clean, fresh water available at all times.',
     grit: 'Do not routinely add grit for parrots unless an exotics vet specifically recommends it.',
   },
   african_grey: {
     scope: 'A seed and grain enrichment mix, not a complete African grey diet.',
-    baseDiet: 'Use a species-appropriate formulated diet as the nutritional base. African greys need guidance from an exotics vet for calcium and vitamin D concerns.',
+    baseDiet: 'Use a species-appropriate formulated diet as the nutritional base, with fresh vegetables and fruit. African greys need guidance from an exotics vet for calcium and vitamin D concerns.',
     water: 'Always provide clean, fresh water available at all times.',
     grit: 'Do not routinely add grit unless an exotics vet specifically recommends it.',
   },
   budgie: {
     scope: 'A seed and grain enrichment mix, not a complete budgie diet.',
-    baseDiet: 'Use a species-appropriate formulated diet as the nutritional base, together with fresh vegetables and limited seed.',
+    baseDiet: 'Use a species-appropriate formulated diet as the nutritional base, together with fresh vegetables, fruit, and limited seed.',
     water: 'Always provide clean, fresh water available at all times.',
     grit: 'Do not routinely add grit unless an exotics vet specifically recommends it.',
   },
   canary: {
     scope: 'A seed and grain enrichment mix, not a complete canary diet.',
-    baseDiet: 'Use a species-appropriate formulated diet or fortified diet as the nutritional base, with fresh food and limited seed.',
+    baseDiet: 'Use a species-appropriate formulated diet or fortified diet as the nutritional base, with fresh vegetables, fruit, and limited seed.',
     water: 'Always provide clean, fresh water available at all times.',
     grit: 'Do not routinely add grit unless an exotics vet specifically recommends it.',
   },
   chicken: {
     scope: 'A scratch-grain supplement mix, not a complete poultry ration. Keep scratch and other treats to a small share of daily intake.',
-    baseDiet: 'Use an age- and production-appropriate complete poultry feed as the nutritional base. Laying hens require a validated layer ration.',
+    baseDiet: 'Use an age- and production-appropriate complete poultry feed as the nutritional base, with insects as occasional enrichment. Laying hens require a validated layer ration.',
     water: 'Provide clean, fresh water continuously; water access strongly affects feed intake and egg production.',
     grit: 'Offer insoluble grit only when feeding whole grains or seeds and birds cannot obtain suitable grit from the ground. Oyster shell is not a grit substitute.',
   },

--- a/v3-webapp/client/src/pages/Home.tsx
+++ b/v3-webapp/client/src/pages/Home.tsx
@@ -62,6 +62,7 @@ export default function Home() {
   const birdProfile = BIRD_PROFILES[selectedBird];
   const currentProfile = birdProfile.profiles[situation] || birdProfile.profiles[availableSituations[0]];
   const care = BIRD_CARE[selectedBird];
+  const gritText = care.gritBySituation?.[situation] ? `${care.grit} ${care.gritBySituation[situation]}` : care.grit;
   const herbRecommendation = useMemo(() => {
     const recommendation = HERB_RECOMMENDATIONS[situation];
     if (!recommendation) return null;
@@ -304,10 +305,10 @@ export default function Home() {
                 </div>
 
                 <Separator />
-                <div className="space-y-4 text-sm">
-                  <CareNote icon={<Droplets className="h-5 w-5 text-blue-600" />} title="Water" text={care.water} />
-                  <CareNote icon={<Scale className="h-5 w-5 text-amber-700" />} title="Grit" text={care.grit} />
-                  <CareNote icon={<BookOpen className="h-5 w-5 text-emerald-600" />} title="Base Diet" text={care.baseDiet} />
+                  <div className="space-y-4 text-sm">
+                    <CareNote icon={<Droplets className="h-5 w-5 text-blue-600" />} title="Water" text={care.water} />
+                    <CareNote icon={<Scale className="h-5 w-5 text-amber-700" />} title="Grit" text={gritText} />
+                    <CareNote icon={<BookOpen className="h-5 w-5 text-emerald-600" />} title="Base Diet" text={care.baseDiet} />
                   {selectedBird === "pigeon" && (
                     <CareNote icon={<Leaf className="h-5 w-5 text-emerald-600" />} title="Fresh Produce" text="Offer small quantities of finely chopped salad greens or grated carrots 2–3 times weekly in a separate dish." />
                   )}

--- a/v3-webapp/package.json
+++ b/v3-webapp/package.json
@@ -15,6 +15,7 @@
     "test:herb-safety": "tsx scripts/verify-herb-safety.mjs",
     "test:inventory-presets": "tsx scripts/verify-inventory-presets.mjs",
     "test:profile-default-formulas": "tsx scripts/verify-profile-default-formulas.mjs",
+    "test:care-guidance": "tsx scripts/verify-care-guidance.mjs",
     "test:issue-submission": "tsx scripts/verify-issue-submission.mjs",
     "test:github-app": "tsx scripts/verify-github-app-auth.mjs",
     "verify:firebase-deploy-credential": "node scripts/verify-firebase-service-account.mjs",

--- a/v3-webapp/scripts/verify-care-guidance.mjs
+++ b/v3-webapp/scripts/verify-care-guidance.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { BIRD_CARE } from "../client/src/lib/birds.ts";
+
+assert.equal(BIRD_CARE.pigeon.baseDiet, "Use a balanced pigeon diet with fresh produce.");
+assert.equal(BIRD_CARE.pigeon.baseDiet.includes("exotics vet"), false);
+assert.equal(
+  BIRD_CARE.pigeon.gritBySituation?.breeding,
+  "During breeding, include suitable shell grit as a calcium source.",
+);
+
+assert.equal(BIRD_CARE.parrot.baseDiet.includes("fresh vegetables and fruit"), true);
+assert.equal(BIRD_CARE.african_grey.baseDiet.includes("fresh vegetables and fruit"), true);
+assert.equal(BIRD_CARE.budgie.baseDiet.includes("fresh vegetables, fruit"), true);
+assert.equal(BIRD_CARE.canary.baseDiet.includes("fresh vegetables, fruit"), true);
+assert.equal(BIRD_CARE.chicken.baseDiet.includes("insects as occasional enrichment"), true);
+
+const homeSource = readFileSync(resolve(import.meta.dirname, "../client/src/pages/Home.tsx"), "utf8");
+assert.match(homeSource, /const gritText = care\.gritBySituation\?\.\[situation\]/);
+assert.match(homeSource, /title="Grit" text=\{gritText\}/);
+
+console.log("Care guidance checks passed.");


### PR DESCRIPTION
Closes #93. Follow-up correction to the care display introduced by merged PR #80.

## Scope

This PR applies only the owner-approved species-specific care-display corrections. It adds one profile-aware rendering rule: the pigeon **Breeding** situation appends its shell-grit calcium sentence to the existing Grit care note. All other changes are confined to the requested Base Diet wording.

## Exact public-facing copy changes

| Location | Before | After | Rationale |
|---|---|---|---|
| Pigeon — Base Diet | `Use a balanced pigeon diet with fresh produce and seek a review from an exotics vet for performance, breeding, or health concerns.` | `Use a balanced pigeon diet with fresh produce.` | Remove the owner-identified, unnecessary review request while retaining the desired fresh-produce point. |
| Pigeon — Breeding — Grit | `Pigeons need grit to properly digest seeds and grains.` | `Pigeons need grit to properly digest seeds and grains. During breeding, include suitable shell grit as a calcium source.` | Display the requested calcium/shell guidance only for the Breeding situation. |
| Parrot — Base Diet | `Use a species-appropriate formulated diet as the nutritional base, with fresh vegetables and only limited seeds or nuts.` | `Use a species-appropriate formulated diet as the nutritional base, with fresh vegetables and fruit, and only limited seeds or nuts.` | Add the requested fruit reference. |
| African Grey — Base Diet | `Use a species-appropriate formulated diet as the nutritional base. African greys need guidance from an exotics vet for calcium and vitamin D concerns.` | `Use a species-appropriate formulated diet as the nutritional base, with fresh vegetables and fruit. African greys need guidance from an exotics vet for calcium and vitamin D concerns.` | Add the requested fruit reference without changing the existing Grey-specific sentence. |
| Budgie — Base Diet | `Use a species-appropriate formulated diet as the nutritional base, together with fresh vegetables and limited seed.` | `Use a species-appropriate formulated diet as the nutritional base, together with fresh vegetables, fruit, and limited seed.` | Add the requested fruit reference. |
| Canary — Base Diet | `Use a species-appropriate formulated diet or fortified diet as the nutritional base, with fresh food and limited seed.` | `Use a species-appropriate formulated diet or fortified diet as the nutritional base, with fresh vegetables, fruit, and limited seed.` | Make the requested fruit reference explicit. |
| Chicken — Base Diet | `Use an age- and production-appropriate complete poultry feed as the nutritional base. Laying hens require a validated layer ration.` | `Use an age- and production-appropriate complete poultry feed as the nutritional base, with insects as occasional enrichment. Laying hens require a validated layer ration.` | Add the requested insect-enrichment point while preserving the complete-feed foundation. |

## Validation

| Check | Result |
|---|---|
| `pnpm --dir v3-webapp test:care-guidance` | Passed. Verifies all approved strings and the breeding-only `gritBySituation` rendering path. |
| `pnpm test:provenance` | Passed. |
| `pnpm check` | Passed. |
| `pnpm test:calculator` | Passed: existing 21 scenarios. |
| `pnpm build` | Passed. Existing bundle-size warning unchanged. |

## What did not change

No profile target, formula, category ratio, ingredient, nutrient value, herb recommendation, safety outcome, compatibility result, warning severity, calculation behavior, inventory behavior, icon, Firebase setting, or deployment behavior changed. The existing Fresh Produce care note remains in place.

## Owner decision requested

Please review the exact visible strings above and the care panel behavior, especially the fact that the shell-grit sentence appears only for Pigeon → Breeding. I will not merge this PR without your approval in Manus chat.
