### PR TITLE
chore(v3): update nanoid to 6

### DIFF
--- a/v3-webapp/package.json
+++ b/v3-webapp/package.json
@@ -61,7 +61,7 @@
     "input-otp": "^1.4.2",
     "jsonwebtoken": "^9.0.3",
     "lucide-react": "^0.453.0",
-    "nanoid": "^5.1.16",
+    "nanoid": "^6.0.1",
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-day-picker": "^9.11.1",

--- a/v3-webapp/pnpm-lock.yaml
+++ b/v3-webapp/pnpm-lock.yaml
@@ -137,8 +137,8 @@ importers:
         specifier: ^0.453.0
         version: 0.453.0(react@19.2.0)
       nanoid:
-        specifier: ^5.1.16
-        version: 5.1.16
+        specifier: ^6.0.1
+        version: 6.0.1
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -3275,6 +3275,11 @@ packages:
   nanoid@5.1.16:
     resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
+    hasBin: true
+
+  nanoid@6.0.1:
+    resolution: {integrity: sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==}
+    engines: {node: ^22 || ^24 || >=26}
     hasBin: true
 
   negotiator@0.6.3:
@@ -7430,6 +7435,8 @@ snapshots:
   nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
+
+  nanoid@6.0.1: {}
 
   negotiator@0.6.3: {}
 


### PR DESCRIPTION
## Scope
This PR splits the active V3 Nano ID change out of Dependabot PR #60. It updates only `v3-webapp/package.json` and its matching `v3-webapp/pnpm-lock.yaml`.

## Why this is separate
The source Dependabot PR combines archived V0/V1/V2 material, active V3 build tooling, and Firebase Functions. This focused PR isolates one runtime dependency change so it can be validated and approved independently.

## Validation
- `pnpm --dir v3-webapp install --frozen-lockfile --ignore-scripts`
- `pnpm --dir v3-webapp check`
- `pnpm --dir v3-webapp test:calculator`
- `pnpm --dir v3-webapp test:herb-safety`
- `pnpm --dir v3-webapp test:issue-submission`
- `pnpm --dir v3-webapp build`
- `git diff --check`

All listed checks passed. Existing build warnings about analytics placeholders and bundle size remain unchanged.

## What did not change
No application source, Firebase rules, formulas, ingredients, safety wording, or public-facing copy changed. No archived material or Firebase Functions dependency changed.

## Related work
- Splitting issue: #95
- Source Dependabot PR: #60

## Owner decision requested
Please review and approve this focused PR in Manus chat before any merge. This PR must remain unmerged until explicit owner approval.