### PR TITLE
chore(v3): update esbuild to 0.28

### DIFF
--- a/v3-webapp/package.json
+++ b/v3-webapp/package.json
@@ -89,7 +89,7 @@
     "@vitejs/plugin-react": "^5.0.4",
     "add": "^2.0.6",
     "autoprefixer": "^10.4.20",
-    "esbuild": "^0.25.0",
+    "esbuild": "^0.28.1",
     "pnpm": "^10.34.4",
     "postcss": "^8.5.26",
     "prettier": "^3.6.2",

--- a/v3-webapp/pnpm-lock.yaml
+++ b/v3-webapp/pnpm-lock.yaml
@@ -216,8 +216,8 @@ importers:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.26)
       esbuild:
-        specifier: ^0.25.0
-        version: 0.25.10
+        specifier: ^0.28.1
+        version: 0.28.2
       pnpm:
         specifier: ^10.34.4
         version: 10.34.4


### PR DESCRIPTION
## Scope
This PR splits the active V3 esbuild update out of Dependabot PR #60. It updates only `v3-webapp/package.json` and the matching `v3-webapp/pnpm-lock.yaml`, moving esbuild from `^0.25.0` to `^0.28.1` with the lockfile resolving `0.28.2`.

## Why this is separate
The source Dependabot PR combines archived V0/V1/V2 material, active V3 tooling, and Firebase Functions. This focused PR isolates esbuild so it can be validated independently. Vite/Vitest major upgrades are intentionally not included because their peer ranges need separate compatibility review.

## Validation
- `pnpm --dir v3-webapp install --frozen-lockfile --ignore-scripts`
- `pnpm --dir v3-webapp check`
- `pnpm --dir v3-webapp test:calculator`
- `pnpm --dir v3-webapp test:herb-safety`
- `pnpm --dir v3-webapp test:issue-submission`
- `pnpm --dir v3-webapp build`
- `git diff --check`

All listed checks passed. Existing analytics-placeholder and bundle-size warnings remain unchanged.

## What did not change
No application source, Firebase rules, formulas, ingredients, safety wording, or public-facing copy changed. No Vite/Vitest, Nano ID, archived, or Firebase Functions dependency changed.

## Related work
- Splitting issue: #95
- Source Dependabot PR: #60

## Owner decision requested
Please review and approve this focused PR in Manus chat before any merge. This PR must remain unmerged until explicit owner approval.