### PR TITLE
feat: add approved Light and pigeon fresh-produce guidance

### DIFF
--- a/v3-webapp/client/src/lib/birds.test.ts
+++ b/v3-webapp/client/src/lib/birds.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { BIRD_CARE, BIRD_TYPES } from "./birds";
+
+describe("canonical bird care guidance", () => {
+  it("provides the approved indoor-light care note for each supported bird", () => {
+    const approvedLightText = "For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.";
+
+    expect(BIRD_TYPES.map((bird) => BIRD_CARE[bird].light)).toEqual(
+      BIRD_TYPES.map(() => approvedLightText),
+    );
+  });
+
+  it("keeps the approved pigeon fresh-produce guidance canonical and excludes it from other birds", () => {
+    expect(BIRD_CARE.pigeon.freshProduce).toBe(
+      "Offer a variety of washed, finely chopped leafy greens and vegetables such as carrot in a separate dish. Add smaller fruit portions, including apple, and remove leftovers promptly; keep fresh foods separate from the dry mix.",
+    );
+    expect(BIRD_TYPES.filter((bird) => bird !== "pigeon").every((bird) => !BIRD_CARE[bird].freshProduce)).toBe(true);
+  });
+});

--- a/v3-webapp/client/src/lib/birds.ts
+++ b/v3-webapp/client/src/lib/birds.ts
@@ -36,6 +36,8 @@ export interface BirdCareGuidance {
   water: string;
   grit: string;
   gritBySituation?: Partial<Record<string, string>>;
+  light: string;
+  freshProduce?: string;
 }
 
 export const BIRD_PROFILES: Record<BirdType, BirdProfile> = {
@@ -358,36 +360,43 @@ export const BIRD_CARE: Record<BirdType, BirdCareGuidance> = {
     gritBySituation: {
       breeding: 'During breeding, include suitable shell grit as a calcium source.',
     },
+    light: 'For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.',
+    freshProduce: 'Offer a variety of washed, finely chopped leafy greens and vegetables such as carrot in a separate dish. Add smaller fruit portions, including apple, and remove leftovers promptly; keep fresh foods separate from the dry mix.',
   },
   parrot: {
     scope: 'A seed and grain enrichment mix, not a complete parrot diet.',
     baseDiet: 'Use a species-appropriate formulated diet as the nutritional base, with fresh vegetables and fruit, and only limited seeds or nuts.',
     water: 'Always provide clean, fresh water available at all times.',
     grit: 'Do not routinely add grit for parrots unless an exotics vet specifically recommends it.',
+    light: 'For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.',
   },
   african_grey: {
     scope: 'A seed and grain enrichment mix, not a complete African grey diet.',
     baseDiet: 'Use a species-appropriate formulated diet as the nutritional base, with fresh vegetables and fruit. African greys need guidance from an exotics vet for calcium and vitamin D concerns.',
     water: 'Always provide clean, fresh water available at all times.',
     grit: 'Do not routinely add grit unless an exotics vet specifically recommends it.',
+    light: 'For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.',
   },
   budgie: {
     scope: 'A seed and grain enrichment mix, not a complete budgie diet.',
     baseDiet: 'Use a species-appropriate formulated diet as the nutritional base, together with fresh vegetables, fruit, and limited seed.',
     water: 'Always provide clean, fresh water available at all times.',
     grit: 'Do not routinely add grit unless an exotics vet specifically recommends it.',
+    light: 'For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.',
   },
   canary: {
     scope: 'A seed and grain enrichment mix, not a complete canary diet.',
     baseDiet: 'Use a species-appropriate formulated diet or fortified diet as the nutritional base, with fresh vegetables, fruit, and limited seed.',
     water: 'Always provide clean, fresh water available at all times.',
     grit: 'Do not routinely add grit unless an exotics vet specifically recommends it.',
+    light: 'For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.',
   },
   chicken: {
     scope: 'A scratch-grain supplement mix, not a complete poultry ration. Keep scratch and other treats to a small share of daily intake.',
     baseDiet: 'Use an age- and production-appropriate complete poultry feed as the nutritional base, with insects as occasional enrichment. Laying hens require a validated layer ration.',
     water: 'Provide clean, fresh water continuously; water access strongly affects feed intake and egg production.',
     grit: 'Offer insoluble grit only when feeding whole grains or seeds and birds cannot obtain suitable grit from the ground. Oyster shell is not a grit substitute.',
+    light: 'For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.',
   },
 };
 

--- a/v3-webapp/client/src/pages/Home.tsx
+++ b/v3-webapp/client/src/pages/Home.tsx
@@ -14,6 +14,7 @@ import {
   Plus,
   Scale,
   Search,
+  Sun,
   Trash2,
   Wheat,
 } from "lucide-react";
@@ -305,13 +306,12 @@ export default function Home() {
                 </div>
 
                 <Separator />
-                  <div className="space-y-4 text-sm">
-                    <CareNote icon={<Droplets className="h-5 w-5 text-blue-600" />} title="Water" text={care.water} />
-                    <CareNote icon={<Scale className="h-5 w-5 text-amber-700" />} title="Grit" text={gritText} />
-                    <CareNote icon={<BookOpen className="h-5 w-5 text-emerald-600" />} title="Base Diet" text={care.baseDiet} />
-                  {selectedBird === "pigeon" && (
-                    <CareNote icon={<Leaf className="h-5 w-5 text-emerald-600" />} title="Fresh Produce" text="Offer small quantities of finely chopped salad greens or grated carrots 2–3 times weekly in a separate dish." />
-                  )}
+                <div className="space-y-4 text-sm">
+                  <CareNote icon={<Droplets className="h-5 w-5 text-blue-600" />} title="Water" text={care.water} />
+                  <CareNote icon={<Scale className="h-5 w-5 text-amber-700" />} title="Grit" text={gritText} />
+                  <CareNote icon={<Sun className="h-5 w-5 text-amber-500" />} title="Light" text={care.light} />
+                  <CareNote icon={<BookOpen className="h-5 w-5 text-emerald-600" />} title="Base Diet" text={care.baseDiet} />
+                  {care.freshProduce && <CareNote icon={<Leaf className="h-5 w-5 text-emerald-600" />} title="Fresh Produce" text={care.freshProduce} />}
                 </div>
               </CardContent>
             </Card>
@@ -437,7 +437,7 @@ export default function Home() {
                     <ReportIssueLink section="Herbs & Supplements" bird={birdProfile.name} profile={currentProfile.name} />
                   </div>}
 
-                  {activeTab === "analysis" && <div className="space-y-8"><div><h2 className="mb-4 text-lg font-bold">Category Breakdown</h2><div className="space-y-4"><CategoryBar label="Grains" value={result.categories.grain} target={getCategoryTargets(selectedBird).grain} color="bg-amber-400" /><CategoryBar label="Legumes" value={result.categories.legume} target={getCategoryTargets(selectedBird).legume} color="bg-emerald-500" /><CategoryBar label="Seeds" value={result.categories.seed} target={getCategoryTargets(selectedBird).seed} color="bg-stone-500" /></div></div><Separator /><div><h2 className="mb-3 text-lg font-bold">Detailed analysis</h2><p className="text-sm text-muted-foreground mb-3">Detailed analysis of the recommended seed mix based on nutritional targets and ingredient properties.</p><div className="mt-4 grid gap-3 sm:grid-cols-2">{result.suggestions.map((suggestion) => <div key={suggestion} className="rounded-lg border bg-muted/20 p-4 text-sm"><CheckCircle2 className="mb-2 h-4 w-4 text-emerald-700" />{suggestion}</div>)}</div><p className="mt-4 text-xs text-muted-foreground">Optimizer note: The optimizer favours the selected profile’s estimated macronutrient and category ranges using the inventory you supplied. It is deterministic: identical inventory and settings produce the same batch estimate.</p></div><div className="rounded-lg border border-blue-200 bg-blue-50 p-4"><h3 className="font-semibold text-blue-950">Profile: {currentProfile.name}</h3><p className="mt-1 text-sm text-blue-900">{currentProfile.feedingNotes}</p></div><ReportIssueLink section="Detailed Analysis" bird={birdProfile.name} profile={currentProfile.name} /></div>}
+                  {activeTab === "analysis" && <div className="space-y-8"><div><h2 className="mb-4 text-lg font-bold">Category Breakdown</h2><div className="space-y-4"><CategoryBar label="Grains" value={result.categories.grain} target={getCategoryTargets(selectedBird).grain} color="bg-amber-400" /><CategoryBar label="Legumes" value={result.categories.legume} target={getCategoryTargets(selectedBird).legume} color="bg-emerald-500" /><CategoryBar label="Seeds" value={result.categories.seed} target={getCategoryTargets(selectedBird).seed} color="bg-stone-500" /></div></div><Separator /><div><h2 className="mb-3 text-lg font-bold">Detailed analysis</h2><p className="text-sm text-muted-foreground mb-3">Detailed analysis of the recommended seed mix based on nutritional targets and ingredient properties.</p><div className="mt-4 grid gap-3 sm:grid-cols-2">{result.suggestions.map((suggestion) => <div key={suggestion} className="rounded-lg border bg-muted/20 p-4 text-sm"><CheckCircle2 className="mb-2 h-4 w-4 text-emerald-700" />{suggestion}</div>)}</div><p className="mt-4 text-xs text-muted-foreground">Optimizer note: The optimizer favours the selected profile’s estimated macronutrient and category ranges using the inventory you supplied. It is deterministic: identical inventory and settings produce the same batch estimate.</p></div><div className="rounded-lg border border-blue-200 bg-blue-50 p-4"><h3 className="font-semibold text-blue-950">Profile: {currentProfile.name}</h3><p className="mt-1 text-sm text-blue-900">{currentProfile.feedingNotes}</p></div><div className="rounded-lg border border-amber-200 bg-amber-50 p-4"><h3 className="flex items-center gap-2 font-semibold text-amber-950"><Sun className="h-4 w-4 text-amber-600" aria-hidden="true" />Environmental Support</h3><p className="mt-1 text-sm text-amber-900">Daylight through closed window glass does not provide useful UVB. UVB supports vitamin-D metabolism and calcium use.</p></div><ReportIssueLink section="Detailed Analysis" bird={birdProfile.name} profile={currentProfile.name} /></div>}
                 </CardContent>
               </Card>
             </div>}

--- a/v3-webapp/todo.md
+++ b/v3-webapp/todo.md
@@ -106,3 +106,5 @@
 - [x] Display canonical compatible-bird badges only in the dedicated Herb Library for Issues #48 and #49, never in calculator cards.
 - [x] Automatically add `Priority` to wrong-information/issue reports and `enhancement` to bird/profile suggestions while preserving existing imported report labels.
 - [x] Render canonical Water, Grit, Base Diet, and pigeon-only Fresh Produce notes together in the profile box for Issue #79.
+- [x] Verify owner-provided pigeon sources and record direct pigeon-specific Apple support in the provenance ledger without changing calculator runtime data.
+- [x] Implement the owner-approved Light card, Detailed Analysis environmental-support note, and revised pigeon fresh-produce wording on Issue #101's review branch.


### PR DESCRIPTION
# Add approved Light and pigeon fresh-produce care guidance

Closes #101.

## Scope

This UI-only PR implements the owner-approved Light card, Detailed Analysis environmental-support note, and revised pigeon Fresh Produce note. Care text is kept in the canonical `BIRD_CARE` model; `Home.tsx` only renders it. The source-only provenance foundation remains in [PR #100](https://github.com/Crypto-Shroom/Bird-Feed-Calculator/pull/100).

## Public-facing copy changes — owner-approved exact text

| Location | Before | After | Rationale |
|---|---|---|---|
| Profile care stack, after **Grit** | No Light care note | “For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.” | The owner approved a compact non-prescriptive Light note, represented with a sun symbol. |
| **Detailed Analysis** | No Environmental Support note | “Daylight through closed window glass does not provide useful UVB. UVB supports vitamin-D metabolism and calcium use.” | The owner directed the explanatory UVB context to the detailed panel rather than the compact profile note. |
| **Pigeon Fresh Produce** | “Offer small quantities of finely chopped salad greens or grated carrots 2–3 times weekly in a separate dish.” | “Offer a variety of washed, finely chopped leafy greens and vegetables such as carrot in a separate dish. Add smaller fruit portions, including apple, and remove leftovers promptly; keep fresh foods separate from the dry mix.” | The owner approved broader vegetables and fruit, specifically Apple, and requested removal of peas and corn from fresh-produce examples because the calculator already treats them as grain/legume-mix ingredients. |

The new **Environmental Support** heading is the structural label for the owner-approved Detailed Analysis note.

## Source and safety boundary

PR #100 now registers direct pigeon-specific Apple support and records Apple for Pigeon as **limited** for fresh, washed flesh with core and seeds removed. This UI PR does not make Apple a dry-mix ingredient, modify its nutrition data, or change any safety/compatibility engine outcome.

## Validation

| Check | Result |
|---|---|
| `pnpm exec vitest run` | Passed: 2 tests, including new care-guidance coverage. |
| `pnpm test:calculator` | Passed: 21 calculator scenarios. |
| `pnpm check` | Passed. |
| `pnpm build` | Passed. Vite emitted its pre-existing chunk-size advisory only. |
| Active preview inspection | Confirmed the Light card follows Grit, displays the sun symbol, shows the approved pigeon Fresh Produce sentence without peas/corn, and Detailed Analysis shows the approved Environmental Support content. |

## What did not change

The calculator optimizer, formulas, ingredient data, nutritional targets, inventory/default-formula behavior, compatibility outcomes, hard red toxicity warnings, raw-adzuki warning, profiles, Firebase configuration, reporting flow, and deployment configuration are unchanged.

## Owner decision requested

Please review the active preview and this PR. I will not merge it until you explicitly approve the pull request here in Manus chat.