### PR TITLE
docs: define owner approval gates for report follow-up

### DIFF
--- a/v3-webapp/docs/governance/OWNER_APPROVAL_WORKFLOW.md
+++ b/v3-webapp/docs/governance/OWNER_APPROVAL_WORKFLOW.md
@@ -1,0 +1,21 @@
+# Owner-approved research and draft-PR workflow
+
+This document records the approval boundary for reports queued from the calculator. It is a governance contract for future automation; it does not authorize a branch, pull request, merge, deployment, formulation change, ingredient change, safety change, or public-facing copy change by itself.
+
+## Two independent gates
+
+| State | Required label state | Permitted action |
+|---|---|---|
+| Submitted | No approval label | Keep the report queued for owner review. |
+| Research approved | `APPROVED` | Perform the requested research and publish cited findings as an issue comment or report. Do not change repository data. |
+| Implementation approved | `APPROVED` and `second approval label` | A separately scoped draft pull request may be created after the research output is reviewed. The draft remains unmerged until the product owner approves it in Manus chat. |
+
+The labels are intentionally evaluated case-insensitively, and unrelated labels do not satisfy either gate. The implementation guard is exposed in `scripts/research-approval.mjs` and covered by `scripts/research-approval.test.ts`.
+
+## Existing queue boundary
+
+The daily Firestore queue processor may create a GitHub issue for a newly submitted report. That intake step is not research approval and must not be interpreted as permission to modify canonical database files, formulas, safety rules, or user-visible copy. Research and implementation remain human-reviewable follow-up steps.
+
+## Owner decision requested
+
+Please review this guard and the linked PR. If approved, a later change may integrate the guard into an explicitly authorized research or draft-PR worker. This PR itself does not create branches or pull requests automatically, and it will not be merged without explicit owner approval.

--- a/v3-webapp/scripts/research-approval.mjs
+++ b/v3-webapp/scripts/research-approval.mjs
@@ -1,0 +1,28 @@
+const RESEARCH_APPROVAL_LABEL = "APPROVED";
+const IMPLEMENTATION_APPROVAL_LABEL = "second approval label";
+
+function normalizeLabels(labels) {
+  return new Set(
+    (labels || [])
+      .map((label) => (typeof label === "string" ? label : label?.name))
+      .filter(Boolean)
+      .map((label) => label.trim().toLowerCase()),
+  );
+}
+
+export function getResearchApprovalState(labels) {
+  const normalized = normalizeLabels(labels);
+  const researchApproved = normalized.has(RESEARCH_APPROVAL_LABEL.toLowerCase());
+  const implementationApproved = normalized.has(IMPLEMENTATION_APPROVAL_LABEL.toLowerCase());
+
+  return {
+    researchApproved,
+    implementationApproved,
+    mayPublishCitedResearch: researchApproved,
+    mayCreateDraftPullRequest: researchApproved && implementationApproved,
+  };
+}
+
+export function mayCreateDraftPullRequest(labels) {
+  return getResearchApprovalState(labels).mayCreateDraftPullRequest;
+}

--- a/v3-webapp/scripts/research-approval.test.ts
+++ b/v3-webapp/scripts/research-approval.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { getResearchApprovalState, mayCreateDraftPullRequest } from "./research-approval.mjs";
+
+describe("research approval gates", () => {
+  it("does not authorize research or implementation from an unlabelled report", () => {
+    expect(getResearchApprovalState([])).toEqual({
+      researchApproved: false,
+      implementationApproved: false,
+      mayPublishCitedResearch: false,
+      mayCreateDraftPullRequest: false,
+    });
+  });
+
+  it("allows cited research after the first approval only", () => {
+    const state = getResearchApprovalState(["needs-research", "APPROVED"]);
+    expect(state.researchApproved).toBe(true);
+    expect(state.mayPublishCitedResearch).toBe(true);
+    expect(state.mayCreateDraftPullRequest).toBe(false);
+  });
+
+  it("requires both approvals before draft-PR automation", () => {
+    expect(mayCreateDraftPullRequest(["APPROVED"])).toBe(false);
+    expect(mayCreateDraftPullRequest(["second approval label"])).toBe(false);
+    expect(mayCreateDraftPullRequest(["APPROVED", "second approval label"])).toBe(true);
+  });
+
+  it("accepts GitHub label objects and ignores unrelated labels", () => {
+    expect(
+      mayCreateDraftPullRequest([
+        { name: "enhancement" },
+        { name: "APPROVED" },
+        { name: "SECOND APPROVAL LABEL" },
+      ]),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Scope

Closes #20.

This PR adds a small, deterministic approval-gate contract for the existing Firestore report queue. It defines the two owner-controlled labels required for follow-up work:

1. `APPROVED` permits cited research output only.
2. `APPROVED` plus `second approval label` permits consideration of a separately scoped draft pull request.

The guard accepts GitHub label strings or label objects, evaluates them case-insensitively, and ignores unrelated labels. The governance document records the queue boundary and the required human review.

## Validation

| Check | Result |
|---|---|
| Focused Vitest approval-gate suite | Passed: 4 tests |
| `pnpm check` | Passed |
| `pnpm test:calculator` | Passed: 21 bird/situation scenarios and safety checks |
| `pnpm test:provenance` | Passed: ledger validation and 3 tests |
| `pnpm build` | Passed; existing analytics placeholders and chunk-size advisories remain |
| `git diff --check` | Passed |

## What did not change

No Firestore region, Firebase rule, queue-processing behavior, GitHub token handling, branch creation, pull-request creation automation, merge behavior, deployment workflow, formula, ingredient, nutrition target, safety rule, provenance record, or public-facing copy changed. No food candidate was added or evaluated, so no cross-species suitability claim was made.

## Public-facing copy

No visitor-visible strings changed.

## Owner decision requested

Please review the focused guard and governance document. I will not merge this PR until you explicitly approve it in Manus chat. A later PR may integrate this guard into an authorized worker only after the owner-controlled approval boundary is confirmed.
