### PR TITLE
feat: add pigeon fresh vegetable and fruit guidance panel

### DIFF
--- a/v3-webapp/client/src/lib/birds.test.ts
+++ b/v3-webapp/client/src/lib/birds.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { BIRD_CARE, BIRD_TYPES } from "./birds";
+
+describe("canonical bird care guidance", () => {
+  it("provides the approved indoor-light care note for each supported bird", () => {
+    const approvedLightText = "For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.";
+
+    expect(BIRD_TYPES.map((bird) => BIRD_CARE[bird].light)).toEqual(
+      BIRD_TYPES.map(() => approvedLightText),
+    );
+  });
+
+  it("keeps the approved pigeon fresh-produce guidance canonical and excludes it from other birds", () => {
+    expect(BIRD_CARE.pigeon.freshProduce).toBe(
+      "Offer a variety of washed, finely chopped leafy greens and vegetables such as carrot in a separate dish. Add smaller fruit portions, including apple, and remove leftovers promptly; keep fresh foods separate from the dry mix.",
+    );
+    expect(BIRD_TYPES.filter((bird) => bird !== "pigeon").every((bird) => !BIRD_CARE[bird].freshProduce)).toBe(true);
+  });
+});

--- a/v3-webapp/client/src/lib/birds.test.ts
+++ b/v3-webapp/client/src/lib/birds.test.ts
@@ -16,4 +16,28 @@ describe("canonical bird care guidance", () => {
     );
     expect(BIRD_TYPES.filter((bird) => bird !== "pigeon").every((bird) => !BIRD_CARE[bird].freshProduce)).toBe(true);
   });
+
+  it("defines the owner-approved pigeon vegetable, fruit, safety, and source-link guidance", () => {
+    const guidance = BIRD_CARE.pigeon.freshProduceGuidance;
+
+    expect(guidance).toMatchObject({
+      triggerLabel: "View suitable fresh vegetables and fruit",
+      heading: "Suitable fresh vegetables and fruit for pigeons",
+      introduction: "Offer fresh, washed, finely chopped or grated vegetables and small pieces of fruit in a separate dish.",
+      vegetables: "Vegetables: carrot, broccoli, cauliflower, bell pepper, dandelion greens, and leafy greens such as kale, romaine, or collard greens.",
+      fruits: "Small fruit portions: apple flesh with the core and seeds removed, and berries.",
+      safety: "Do not offer avocado, onion, or rhubarb. Remove leftovers promptly.",
+      sourcesTriggerLabel: "Sources for this guidance",
+      sourcesHeading: "Sources for fresh vegetable and fruit guidance",
+    });
+    expect(guidance?.sources).toHaveLength(5);
+    expect(guidance?.sources.map((source) => source.url)).toEqual([
+      "https://vcahospitals.com/know-your-pet/pigeons-and-doves-feeding",
+      "https://www.melbournebirdvet.com/post/diet-for-pet-pigeons",
+      "https://www.pigeonrescue.org/birds/care/pigeon-feeding-dove-feeding/",
+      "https://modernpetpigeonsociety.miraheze.org/wiki/Fruits_and_vegetables",
+      "https://pigeoncaretips.com/what-do-pigeons-eat/",
+    ]);
+    expect(BIRD_TYPES.filter((bird) => bird !== "pigeon").every((bird) => !BIRD_CARE[bird].freshProduceGuidance)).toBe(true);
+  });
 });

--- a/v3-webapp/client/src/lib/birds.ts
+++ b/v3-webapp/client/src/lib/birds.ts
@@ -30,6 +30,23 @@ export interface CategoryTargets {
   seed: [number, number];
 }
 
+export interface CareSourceLink {
+  label: string;
+  url: string;
+}
+
+export interface FreshProduceGuidance {
+  triggerLabel: string;
+  heading: string;
+  introduction: string;
+  vegetables: string;
+  fruits: string;
+  safety: string;
+  sourcesTriggerLabel: string;
+  sourcesHeading: string;
+  sources: CareSourceLink[];
+}
+
 export interface BirdCareGuidance {
   scope: string;
   baseDiet: string;
@@ -37,6 +54,7 @@ export interface BirdCareGuidance {
   grit: string;
   light: string;
   freshProduce?: string;
+  freshProduceGuidance?: FreshProduceGuidance;
 }
 
 export const BIRD_PROFILES: Record<BirdType, BirdProfile> = {
@@ -358,6 +376,23 @@ export const BIRD_CARE: Record<BirdType, BirdCareGuidance> = {
     grit: 'Pigeons need grit to properly digest seeds and grains.',
     light: 'For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.',
     freshProduce: 'Offer a variety of washed, finely chopped leafy greens and vegetables such as carrot in a separate dish. Add smaller fruit portions, including apple, and remove leftovers promptly; keep fresh foods separate from the dry mix.',
+    freshProduceGuidance: {
+      triggerLabel: 'View suitable fresh vegetables and fruit',
+      heading: 'Suitable fresh vegetables and fruit for pigeons',
+      introduction: 'Offer fresh, washed, finely chopped or grated vegetables and small pieces of fruit in a separate dish.',
+      vegetables: 'Vegetables: carrot, broccoli, cauliflower, bell pepper, dandelion greens, and leafy greens such as kale, romaine, or collard greens.',
+      fruits: 'Small fruit portions: apple flesh with the core and seeds removed, and berries.',
+      safety: 'Do not offer avocado, onion, or rhubarb. Remove leftovers promptly.',
+      sourcesTriggerLabel: 'Sources for this guidance',
+      sourcesHeading: 'Sources for fresh vegetable and fruit guidance',
+      sources: [
+        { label: 'VCA: Feeding Pigeons and Doves', url: 'https://vcahospitals.com/know-your-pet/pigeons-and-doves-feeding' },
+        { label: 'Melbourne Bird Veterinary Clinic: Diet for Pet Pigeons', url: 'https://www.melbournebirdvet.com/post/diet-for-pet-pigeons' },
+        { label: 'Palomacy: Pigeon feeding and dove feeding', url: 'https://www.pigeonrescue.org/birds/care/pigeon-feeding-dove-feeding/' },
+        { label: 'Modern Pet Pigeon Society: Fruits and vegetables', url: 'https://modernpetpigeonsociety.miraheze.org/wiki/Fruits_and_vegetables' },
+        { label: 'Pigeon Care Tips: What do pigeons eat?', url: 'https://pigeoncaretips.com/what-do-pigeons-eat/' },
+      ],
+    },
   },
   parrot: {
     scope: 'A seed and grain enrichment mix, not a complete parrot diet.',

--- a/v3-webapp/client/src/lib/birds.ts
+++ b/v3-webapp/client/src/lib/birds.ts
@@ -35,6 +35,8 @@ export interface BirdCareGuidance {
   baseDiet: string;
   water: string;
   grit: string;
+  light: string;
+  freshProduce?: string;
 }
 
 export const BIRD_PROFILES: Record<BirdType, BirdProfile> = {
@@ -354,36 +356,43 @@ export const BIRD_CARE: Record<BirdType, BirdCareGuidance> = {
     baseDiet: 'Use a balanced pigeon diet with fresh produce and seek a review from an exotics vet for performance, breeding, or health concerns.',
     water: 'Always provide clean, fresh water available at all times.',
     grit: 'Pigeons need grit to properly digest seeds and grains.',
+    light: 'For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.',
+    freshProduce: 'Offer a variety of washed, finely chopped leafy greens and vegetables such as carrot in a separate dish. Add smaller fruit portions, including apple, and remove leftovers promptly; keep fresh foods separate from the dry mix.',
   },
   parrot: {
     scope: 'A seed and grain enrichment mix, not a complete parrot diet.',
     baseDiet: 'Use a species-appropriate formulated diet as the nutritional base, with fresh vegetables and only limited seeds or nuts.',
     water: 'Always provide clean, fresh water available at all times.',
     grit: 'Do not routinely add grit for parrots unless an exotics vet specifically recommends it.',
+    light: 'For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.',
   },
   african_grey: {
     scope: 'A seed and grain enrichment mix, not a complete African grey diet.',
     baseDiet: 'Use a species-appropriate formulated diet as the nutritional base. African greys need guidance from an exotics vet for calcium and vitamin D concerns.',
     water: 'Always provide clean, fresh water available at all times.',
     grit: 'Do not routinely add grit unless an exotics vet specifically recommends it.',
+    light: 'For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.',
   },
   budgie: {
     scope: 'A seed and grain enrichment mix, not a complete budgie diet.',
     baseDiet: 'Use a species-appropriate formulated diet as the nutritional base, together with fresh vegetables and limited seed.',
     water: 'Always provide clean, fresh water available at all times.',
     grit: 'Do not routinely add grit unless an exotics vet specifically recommends it.',
+    light: 'For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.',
   },
   canary: {
     scope: 'A seed and grain enrichment mix, not a complete canary diet.',
     baseDiet: 'Use a species-appropriate formulated diet or fortified diet as the nutritional base, with fresh food and limited seed.',
     water: 'Always provide clean, fresh water available at all times.',
     grit: 'Do not routinely add grit unless an exotics vet specifically recommends it.',
+    light: 'For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.',
   },
   chicken: {
     scope: 'A scratch-grain supplement mix, not a complete poultry ration. Keep scratch and other treats to a small share of daily intake.',
     baseDiet: 'Use an age- and production-appropriate complete poultry feed as the nutritional base. Laying hens require a validated layer ration.',
     water: 'Provide clean, fresh water continuously; water access strongly affects feed intake and egg production.',
     grit: 'Offer insoluble grit only when feeding whole grains or seeds and birds cannot obtain suitable grit from the ground. Oyster shell is not a grit substitute.',
+    light: 'For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.',
   },
 };
 

--- a/v3-webapp/client/src/pages/Home.tsx
+++ b/v3-webapp/client/src/pages/Home.tsx
@@ -14,6 +14,7 @@ import {
   Plus,
   Scale,
   Search,
+  Sun,
   Trash2,
   Wheat,
 } from "lucide-react";
@@ -307,10 +308,9 @@ export default function Home() {
                 <div className="space-y-4 text-sm">
                   <CareNote icon={<Droplets className="h-5 w-5 text-blue-600" />} title="Water" text={care.water} />
                   <CareNote icon={<Scale className="h-5 w-5 text-amber-700" />} title="Grit" text={care.grit} />
+                  <CareNote icon={<Sun className="h-5 w-5 text-amber-500" />} title="Light" text={care.light} />
                   <CareNote icon={<BookOpen className="h-5 w-5 text-emerald-600" />} title="Base Diet" text={care.baseDiet} />
-                  {selectedBird === "pigeon" && (
-                    <CareNote icon={<Leaf className="h-5 w-5 text-emerald-600" />} title="Fresh Produce" text="Offer small quantities of finely chopped salad greens or grated carrots 2–3 times weekly in a separate dish." />
-                  )}
+                  {care.freshProduce && <CareNote icon={<Leaf className="h-5 w-5 text-emerald-600" />} title="Fresh Produce" text={care.freshProduce} />}
                 </div>
               </CardContent>
             </Card>
@@ -436,7 +436,7 @@ export default function Home() {
                     <ReportIssueLink section="Herbs & Supplements" bird={birdProfile.name} profile={currentProfile.name} />
                   </div>}
 
-                  {activeTab === "analysis" && <div className="space-y-8"><div><h2 className="mb-4 text-lg font-bold">Category Breakdown</h2><div className="space-y-4"><CategoryBar label="Grains" value={result.categories.grain} target={getCategoryTargets(selectedBird).grain} color="bg-amber-400" /><CategoryBar label="Legumes" value={result.categories.legume} target={getCategoryTargets(selectedBird).legume} color="bg-emerald-500" /><CategoryBar label="Seeds" value={result.categories.seed} target={getCategoryTargets(selectedBird).seed} color="bg-stone-500" /></div></div><Separator /><div><h2 className="mb-3 text-lg font-bold">Detailed analysis</h2><p className="text-sm text-muted-foreground mb-3">Detailed analysis of the recommended seed mix based on nutritional targets and ingredient properties.</p><div className="mt-4 grid gap-3 sm:grid-cols-2">{result.suggestions.map((suggestion) => <div key={suggestion} className="rounded-lg border bg-muted/20 p-4 text-sm"><CheckCircle2 className="mb-2 h-4 w-4 text-emerald-700" />{suggestion}</div>)}</div><p className="mt-4 text-xs text-muted-foreground">Optimizer note: The optimizer favours the selected profile’s estimated macronutrient and category ranges using the inventory you supplied. It is deterministic: identical inventory and settings produce the same batch estimate.</p></div><div className="rounded-lg border border-blue-200 bg-blue-50 p-4"><h3 className="font-semibold text-blue-950">Profile: {currentProfile.name}</h3><p className="mt-1 text-sm text-blue-900">{currentProfile.feedingNotes}</p></div><ReportIssueLink section="Detailed Analysis" bird={birdProfile.name} profile={currentProfile.name} /></div>}
+                  {activeTab === "analysis" && <div className="space-y-8"><div><h2 className="mb-4 text-lg font-bold">Category Breakdown</h2><div className="space-y-4"><CategoryBar label="Grains" value={result.categories.grain} target={getCategoryTargets(selectedBird).grain} color="bg-amber-400" /><CategoryBar label="Legumes" value={result.categories.legume} target={getCategoryTargets(selectedBird).legume} color="bg-emerald-500" /><CategoryBar label="Seeds" value={result.categories.seed} target={getCategoryTargets(selectedBird).seed} color="bg-stone-500" /></div></div><Separator /><div><h2 className="mb-3 text-lg font-bold">Detailed analysis</h2><p className="text-sm text-muted-foreground mb-3">Detailed analysis of the recommended seed mix based on nutritional targets and ingredient properties.</p><div className="mt-4 grid gap-3 sm:grid-cols-2">{result.suggestions.map((suggestion) => <div key={suggestion} className="rounded-lg border bg-muted/20 p-4 text-sm"><CheckCircle2 className="mb-2 h-4 w-4 text-emerald-700" />{suggestion}</div>)}</div><p className="mt-4 text-xs text-muted-foreground">Optimizer note: The optimizer favours the selected profile’s estimated macronutrient and category ranges using the inventory you supplied. It is deterministic: identical inventory and settings produce the same batch estimate.</p></div><div className="rounded-lg border border-blue-200 bg-blue-50 p-4"><h3 className="font-semibold text-blue-950">Profile: {currentProfile.name}</h3><p className="mt-1 text-sm text-blue-900">{currentProfile.feedingNotes}</p></div><div className="rounded-lg border border-amber-200 bg-amber-50 p-4"><h3 className="flex items-center gap-2 font-semibold text-amber-950"><Sun className="h-4 w-4 text-amber-600" aria-hidden="true" />Environmental Support</h3><p className="mt-1 text-sm text-amber-900">Daylight through closed window glass does not provide useful UVB. UVB supports vitamin-D metabolism and calcium use.</p></div><ReportIssueLink section="Detailed Analysis" bird={birdProfile.name} profile={currentProfile.name} /></div>}
                 </CardContent>
               </Card>
             </div>}

--- a/v3-webapp/client/src/pages/Home.tsx
+++ b/v3-webapp/client/src/pages/Home.tsx
@@ -310,7 +310,7 @@ export default function Home() {
                   <CareNote icon={<Scale className="h-5 w-5 text-amber-700" />} title="Grit" text={care.grit} />
                   <CareNote icon={<Sun className="h-5 w-5 text-amber-500" />} title="Light" text={care.light} />
                   <CareNote icon={<BookOpen className="h-5 w-5 text-emerald-600" />} title="Base Diet" text={care.baseDiet} />
-                  {care.freshProduce && <CareNote icon={<Leaf className="h-5 w-5 text-emerald-600" />} title="Fresh Produce" text={care.freshProduce} />}
+                  {care.freshProduce && <FreshProduceCareNote text={care.freshProduce} guidance={care.freshProduceGuidance} />}
                 </div>
               </CardContent>
             </Card>
@@ -451,6 +451,64 @@ export default function Home() {
 
 function CareNote({ icon, title, text }: { icon: React.ReactNode; title: string; text: string }) {
   return <div className="flex items-start gap-3"><div className="mt-0.5 shrink-0">{icon}</div><div><p className="font-medium text-foreground">{title}</p><p className="text-xs leading-relaxed text-muted-foreground">{text}</p></div></div>;
+}
+
+function FreshProduceCareNote({ text, guidance }: { text: string; guidance?: NonNullable<typeof BIRD_CARE.pigeon.freshProduceGuidance> }) {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="mt-0.5 shrink-0"><Leaf className="h-5 w-5 text-emerald-600" /></div>
+      <div className="min-w-0">
+        <p className="font-medium text-foreground">Fresh Produce</p>
+        <p className="text-xs leading-relaxed text-muted-foreground">{text}</p>
+        {guidance && (
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button type="button" variant="outline" size="sm" className="mt-3 h-auto whitespace-normal px-2.5 py-1.5 text-left text-xs text-emerald-900 hover:bg-emerald-50">
+                <Leaf className="mr-1.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                {guidance.triggerLabel}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="w-[min(92vw,430px)] p-4" aria-label={guidance.heading}>
+              <ScrollArea className="max-h-[65vh] pr-3">
+                <div className="space-y-3">
+                  <div>
+                    <h3 className="font-semibold text-foreground">{guidance.heading}</h3>
+                    <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{guidance.introduction}</p>
+                  </div>
+                  <div className="rounded-md bg-emerald-50 p-3 text-sm leading-relaxed text-emerald-950">
+                    <p>{guidance.vegetables}</p>
+                    <p className="mt-2">{guidance.fruits}</p>
+                  </div>
+                  <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm font-medium leading-relaxed text-red-950">{guidance.safety}</p>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button type="button" variant="ghost" size="sm" className="h-auto px-0 py-1 text-xs text-emerald-800 hover:bg-transparent hover:text-emerald-950">
+                        <ExternalLink className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+                        {guidance.sourcesTriggerLabel}
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent align="start" className="w-[min(88vw,360px)] p-4" aria-label={guidance.sourcesHeading}>
+                      <h4 className="text-sm font-semibold text-foreground">{guidance.sourcesHeading}</h4>
+                      <ul className="mt-3 space-y-2">
+                        {guidance.sources.map((source) => (
+                          <li key={source.url}>
+                            <a href={source.url} target="_blank" rel="noreferrer" className="inline-flex items-start gap-1 text-sm leading-snug text-emerald-800 underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+                              <ExternalLink className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                              {source.label}
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              </ScrollArea>
+            </PopoverContent>
+          </Popover>
+        )}
+      </div>
+    </div>
+  );
 }
 
 function ReportIssueLink({ section, bird, profile }: { section: string; bird: string; profile: string }) {

--- a/v3-webapp/todo.md
+++ b/v3-webapp/todo.md
@@ -106,3 +106,5 @@
 - [x] Display canonical compatible-bird badges only in the dedicated Herb Library for Issues #48 and #49, never in calculator cards.
 - [x] Automatically add `Priority` to wrong-information/issue reports and `enhancement` to bird/profile suggestions while preserving existing imported report labels.
 - [x] Render canonical Water, Grit, Base Diet, and pigeon-only Fresh Produce notes together in the profile box for Issue #79.
+- [x] Verify owner-provided pigeon sources and record direct pigeon-specific Apple support in the provenance ledger without changing calculator runtime data.
+- [x] Implement the owner-approved Light card, Detailed Analysis environmental-support note, and revised pigeon fresh-produce wording on Issue #101's review branch.


### PR DESCRIPTION
## Summary

Implements the owner-approved pigeon Fresh Produce guidance and on-site source-links panels under related Issue #98.

## Exact visitor-visible changes

- Added “View suitable fresh vegetables and fruit”.
- Added “Suitable fresh vegetables and fruit for pigeons”.
- Added the approved washed/chopped/grated separate-dish, vegetable, fruit, and explicit safety strings.
- Added “Sources for this guidance” and “Sources for fresh vegetable and fruit guidance”, containing the five approved source links.

## Scope and validation

No inventory, formula, nutrition, compatibility, herb, toxicity, or raw-legume behavior changes. `pnpm exec vitest run`, calculator/herb/inventory/profile-default/issue-submission checks, type check, and production build all passed.

## Dependency

This branch targets PR #102 to preserve its approved Light/Fresh Produce card. It depends on the evidence boundary in PR #100 and must be rebased/revalidated after #100, #94, and #102 merge. Do not merge without explicit owner instruction.