### PR TITLE
feat: add pigeon fresh vegetable and fruit guidance panel

### DIFF
--- a/v3-webapp/client/src/lib/birds.test.ts
+++ b/v3-webapp/client/src/lib/birds.test.ts
@@ -16,4 +16,28 @@ describe("canonical bird care guidance", () => {
     );
     expect(BIRD_TYPES.filter((bird) => bird !== "pigeon").every((bird) => !BIRD_CARE[bird].freshProduce)).toBe(true);
   });
+
+  it("defines the owner-approved pigeon vegetable, fruit, safety, and source-link guidance", () => {
+    const guidance = BIRD_CARE.pigeon.freshProduceGuidance;
+
+    expect(guidance).toMatchObject({
+      triggerLabel: "View suitable fresh vegetables and fruit",
+      heading: "Suitable fresh vegetables and fruit for pigeons",
+      introduction: "Offer fresh, washed, finely chopped or grated vegetables and small pieces of fruit in a separate dish.",
+      vegetables: "Vegetables: carrot, broccoli, cauliflower, bell pepper, dandelion greens, and leafy greens such as kale, romaine, or collard greens.",
+      fruits: "Small fruit portions: apple flesh with the core and seeds removed, and berries.",
+      safety: "Do not offer avocado, onion, or rhubarb. Remove leftovers promptly.",
+      sourcesTriggerLabel: "Sources for this guidance",
+      sourcesHeading: "Sources for fresh vegetable and fruit guidance",
+    });
+    expect(guidance?.sources).toHaveLength(5);
+    expect(guidance?.sources.map((source) => source.url)).toEqual([
+      "https://vcahospitals.com/know-your-pet/pigeons-and-doves-feeding",
+      "https://www.melbournebirdvet.com/post/diet-for-pet-pigeons",
+      "https://www.pigeonrescue.org/birds/care/pigeon-feeding-dove-feeding/",
+      "https://modernpetpigeonsociety.miraheze.org/wiki/Fruits_and_vegetables",
+      "https://pigeoncaretips.com/what-do-pigeons-eat/",
+    ]);
+    expect(BIRD_TYPES.filter((bird) => bird !== "pigeon").every((bird) => !BIRD_CARE[bird].freshProduceGuidance)).toBe(true);
+  });
 });

--- a/v3-webapp/client/src/lib/birds.ts
+++ b/v3-webapp/client/src/lib/birds.ts
@@ -30,6 +30,23 @@ export interface CategoryTargets {
   seed: [number, number];
 }
 
+export interface CareSourceLink {
+  label: string;
+  url: string;
+}
+
+export interface FreshProduceGuidance {
+  triggerLabel: string;
+  heading: string;
+  introduction: string;
+  vegetables: string;
+  fruits: string;
+  safety: string;
+  sourcesTriggerLabel: string;
+  sourcesHeading: string;
+  sources: CareSourceLink[];
+}
+
 export interface BirdCareGuidance {
   scope: string;
   baseDiet: string;
@@ -38,6 +55,7 @@ export interface BirdCareGuidance {
   gritBySituation?: Partial<Record<string, string>>;
   light: string;
   freshProduce?: string;
+  freshProduceGuidance?: FreshProduceGuidance;
 }
 
 export const BIRD_PROFILES: Record<BirdType, BirdProfile> = {
@@ -362,6 +380,23 @@ export const BIRD_CARE: Record<BirdType, BirdCareGuidance> = {
     },
     light: 'For indoor birds, provide safe natural daylight or a species-appropriate avian UVB setup with a shaded retreat.',
     freshProduce: 'Offer a variety of washed, finely chopped leafy greens and vegetables such as carrot in a separate dish. Add smaller fruit portions, including apple, and remove leftovers promptly; keep fresh foods separate from the dry mix.',
+    freshProduceGuidance: {
+      triggerLabel: 'View suitable fresh vegetables and fruit',
+      heading: 'Suitable fresh vegetables and fruit for pigeons',
+      introduction: 'Offer fresh, washed, finely chopped or grated vegetables and small pieces of fruit in a separate dish.',
+      vegetables: 'Vegetables: carrot, broccoli, cauliflower, bell pepper, dandelion greens, and leafy greens such as kale, romaine, or collard greens.',
+      fruits: 'Small fruit portions: apple flesh with the core and seeds removed, and berries.',
+      safety: 'Do not offer avocado, onion, or rhubarb. Remove leftovers promptly.',
+      sourcesTriggerLabel: 'Sources for this guidance',
+      sourcesHeading: 'Sources for fresh vegetable and fruit guidance',
+      sources: [
+        { label: 'VCA: Feeding Pigeons and Doves', url: 'https://vcahospitals.com/know-your-pet/pigeons-and-doves-feeding' },
+        { label: 'Melbourne Bird Veterinary Clinic: Diet for Pet Pigeons', url: 'https://www.melbournebirdvet.com/post/diet-for-pet-pigeons' },
+        { label: 'Palomacy: Pigeon feeding and dove feeding', url: 'https://www.pigeonrescue.org/birds/care/pigeon-feeding-dove-feeding/' },
+        { label: 'Modern Pet Pigeon Society: Fruits and vegetables', url: 'https://modernpetpigeonsociety.miraheze.org/wiki/Fruits_and_vegetables' },
+        { label: 'Pigeon Care Tips: What do pigeons eat?', url: 'https://pigeoncaretips.com/what-do-pigeons-eat/' },
+      ],
+    },
   },
   parrot: {
     scope: 'A seed and grain enrichment mix, not a complete parrot diet.',

--- a/v3-webapp/client/src/pages/Home.tsx
+++ b/v3-webapp/client/src/pages/Home.tsx
@@ -311,7 +311,7 @@ export default function Home() {
                   <CareNote icon={<Scale className="h-5 w-5 text-amber-700" />} title="Grit" text={gritText} />
                   <CareNote icon={<Sun className="h-5 w-5 text-amber-500" />} title="Light" text={care.light} />
                   <CareNote icon={<BookOpen className="h-5 w-5 text-emerald-600" />} title="Base Diet" text={care.baseDiet} />
-                  {care.freshProduce && <CareNote icon={<Leaf className="h-5 w-5 text-emerald-600" />} title="Fresh Produce" text={care.freshProduce} />}
+                  {care.freshProduce && <FreshProduceCareNote text={care.freshProduce} guidance={care.freshProduceGuidance} />}
                 </div>
               </CardContent>
             </Card>
@@ -452,6 +452,64 @@ export default function Home() {
 
 function CareNote({ icon, title, text }: { icon: React.ReactNode; title: string; text: string }) {
   return <div className="flex items-start gap-3"><div className="mt-0.5 shrink-0">{icon}</div><div><p className="font-medium text-foreground">{title}</p><p className="text-xs leading-relaxed text-muted-foreground">{text}</p></div></div>;
+}
+
+function FreshProduceCareNote({ text, guidance }: { text: string; guidance?: NonNullable<typeof BIRD_CARE.pigeon.freshProduceGuidance> }) {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="mt-0.5 shrink-0"><Leaf className="h-5 w-5 text-emerald-600" /></div>
+      <div className="min-w-0">
+        <p className="font-medium text-foreground">Fresh Produce</p>
+        <p className="text-xs leading-relaxed text-muted-foreground">{text}</p>
+        {guidance && (
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button type="button" variant="outline" size="sm" className="mt-3 h-auto whitespace-normal px-2.5 py-1.5 text-left text-xs text-emerald-900 hover:bg-emerald-50">
+                <Leaf className="mr-1.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                {guidance.triggerLabel}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="w-[min(92vw,430px)] p-4" aria-label={guidance.heading}>
+              <ScrollArea className="max-h-[65vh] pr-3">
+                <div className="space-y-3">
+                  <div>
+                    <h3 className="font-semibold text-foreground">{guidance.heading}</h3>
+                    <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{guidance.introduction}</p>
+                  </div>
+                  <div className="rounded-md bg-emerald-50 p-3 text-sm leading-relaxed text-emerald-950">
+                    <p>{guidance.vegetables}</p>
+                    <p className="mt-2">{guidance.fruits}</p>
+                  </div>
+                  <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm font-medium leading-relaxed text-red-950">{guidance.safety}</p>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button type="button" variant="ghost" size="sm" className="h-auto px-0 py-1 text-xs text-emerald-800 hover:bg-transparent hover:text-emerald-950">
+                        <ExternalLink className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+                        {guidance.sourcesTriggerLabel}
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent align="start" className="w-[min(88vw,360px)] p-4" aria-label={guidance.sourcesHeading}>
+                      <h4 className="text-sm font-semibold text-foreground">{guidance.sourcesHeading}</h4>
+                      <ul className="mt-3 space-y-2">
+                        {guidance.sources.map((source) => (
+                          <li key={source.url}>
+                            <a href={source.url} target="_blank" rel="noreferrer" className="inline-flex items-start gap-1 text-sm leading-snug text-emerald-800 underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+                              <ExternalLink className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                              {source.label}
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              </ScrollArea>
+            </PopoverContent>
+          </Popover>
+        )}
+      </div>
+    </div>
+  );
 }
 
 function ReportIssueLink({ section, bird, profile }: { section: string; bird: string; profile: string }) {


### PR DESCRIPTION
## Replacement for closed PR #104

PR #104 was automatically closed when its temporary base branch was merged and retired. This replacement is the same owner-approved, conflict-resolved fresh-guidance interaction, rebased and validated on current `main`.

## Exact visitor-visible changes

- Added “View suitable fresh vegetables and fruit”.
- Added “Suitable fresh vegetables and fruit for pigeons”.
- Added the owner-approved fresh vegetable, fruit, and explicit safety wording.
- Added the on-site “Sources for this guidance” panel containing all five approved source links.

## What did not change

No inventory, dry-batch input, nutrition value, formula, compatibility outcome, herb recommendation, toxicity rule, or raw-legume warning changed. All PR #94 and #102 care guidance remains preserved.

## Validation

Full Vitest (9 assertions), calculator scenarios (21), herb safety, inventory presets, profile default formulas, issue-submission fallback, type check, and production build passed.

Owner authorized the merge-and-rebase sequence in Manus chat. Do not merge without preserving the documented source and care boundaries.