### PR TITLE
docs(provenance): review five raw legume forms

### DIFF
--- a/database/provenance/evidence/raw-legume-batch-1.md
+++ b/database/provenance/evidence/raw-legume-batch-1.md
@@ -1,0 +1,59 @@
+# Raw Legume Batch 1 — Five Food/Form Reviews
+
+> **Provenance-only boundary.** This note documents evidence for five protected historical raw-legume forms. It does not alter calculator outcomes, active inventory options, recommended formulas, safety copy, nutrient values, or visitor-visible instructions.
+
+## Scope and method
+
+The batch completes explicit six-bird reviews for **raw dried lentil seeds**, **raw dried split pea cotyledons**, **raw dried mung beans**, **raw mature dried garden peas**, and **raw dried kidney beans**. Each form is intentionally distinct from cooked, sprouted, fresh, flour, canned, or processed forms. Results are recorded in `food-reviews.json` and linked to the corresponding protected historical raw-legume coverage items.
+
+The research used direct pigeon owner guidance, direct parrot/canary/budgie/African-Grey feeding guidance, and chicken feed studies where available. A source for one species was never used to establish another species’ outcome. Where the direct chicken raw-mung evidence could not be accessed in full, that row remains `unresolved` rather than relying on a search snippet.
+
+| Food/form | Pigeon | Parrot | African Grey | Budgie | Canary | Chicken |
+| --- | --- | --- | --- | --- | --- | --- |
+| Raw dried lentil seeds | `limited` | `requires_preparation` | `requires_preparation` | `requires_preparation` | `requires_preparation` | `limited` |
+| Raw dried split pea cotyledons | `limited` | `requires_preparation` | `requires_preparation` | `requires_preparation` | `requires_preparation` | `limited` |
+| Raw dried mung beans | `limited` | `requires_preparation` | `requires_preparation` | `requires_preparation` | `requires_preparation` | `unresolved` |
+| Raw mature dried garden peas | `limited` | `requires_preparation` | `requires_preparation` | `requires_preparation` | `requires_preparation` | `limited` |
+| Raw dried kidney beans | `unresolved` | `requires_preparation` | `requires_preparation` | `requires_preparation` | `requires_preparation` | `requires_preparation` |
+
+## Pigeon evidence
+
+The direct **Pigeon Diet Guide** names dried lentils, split peas, mung beans, and dried peas in a pigeon feed/treat context, so those rows are retained as `limited` rather than unresolved. The guide has no populated references section and does not set raw-form preparation, inclusion rate, nutrient, or formula rules. It therefore cannot support a broader approval. It does not name kidney beans. A separate targeted pigeon search produced only inaccessible social posts, conflicting community assertions, and general pigeon feeding sources that did not address raw kidney beans. The kidney-bean pigeon row remains `unresolved`.
+
+## Parrot and companion-bird evidence
+
+For the general parrot row, Petcraft explicitly lists lentils and yellow/green split peas among pulses that must be cooked. The For the Birds rescue guidance identifies lentils, mung beans, and sweet/green peas as sproutable and says kidney beans should be fully cooked. Both are preparation-bound owner guidance and do not supply a formula, portion, or complete diet.
+
+For African Grey, budgie, and canary rows, VCA pages provide species-specific veterinary context. African Grey and budgie guidance list cooked beans; canary guidance explicitly lists lentils, mung, and kidney beans under a cooked-bean heading. All companion records therefore use `requires_preparation` rather than treating any raw dried form as approved.
+
+## Chicken evidence
+
+The raw lentil record is limited to a cited controlled Cobb 500 broiler study in which raw lentil seed appeared in balanced experimental diets at 200 or 400 g/kg. The raw mature garden-pea and raw split-pea records are limited to the poultry feed/formulation context described in a peer-reviewed field-pea review. Neither record is a household-feeding rule or complete-ration instruction.
+
+The raw kidney-bean result is a stronger preparation boundary. A 56-day broiler study reported poorer performance and adverse organ-histology findings for raw/dehulled kidney-bean meals, while aqueous-heated meal did not show the reported adverse effects in the study. The row is consequently `requires_preparation`, without prescribing a preparation method or household inclusion rate.
+
+Accessible full text for candidate raw-mung chicken studies could not be verified. The batch retains that chicken row as `unresolved`; the search and exclusion reason are recorded in the batch research log rather than converting a snippet into an evidence claim.
+
+## What this batch does not do
+
+This five-item research increment does not approve any raw legume for runtime use, create a portion or recipe, set a poultry ration, change red hard-toxicity warnings, alter public wording, infer a result across species, or close Issue #92. It only converts five historically protected food/form obligations into complete, explicit six-bird provenance records.
+
+## References
+
+[1] [Columbidae Ownership Omnibus, *Pigeon Diet Guide*](https://www.pigeon.guide/Pigeon-Diet-Guide-f696d4f98d994603b367803aba5f0ce8)
+
+[2] [Petcraft, *Cooking Beans for Parrots*](https://www.petcraft.com/articles/2014/10/12/cooking-beans-for-parrots/)
+
+[3] [For the Birds Parrot Rescue & Sanctuary, *Legume Safety Warning*](https://www.ftbrescue.com/post/2018/01/13/legume-safety-warning)
+
+[4] [VCA Animal Hospitals, *African Grey Parrots – Feeding*](https://vcahospitals.com/know-your-pet/african-grey-feeding)
+
+[5] [VCA Animal Hospitals, *Budgies – Feeding*](https://vcahospitals.com/know-your-pet/budgies-feeding)
+
+[6] [VCA Animal Hospitals, *Canaries – Feeding*](https://vcahospitals.com/know-your-pet/canaries-feeding)
+
+[7] [Ciurescu et al. (2017), *Beneficial Effects of Increasing Dietary Levels of Raw Lentil Seeds on Meat Fatty Acid and Plasma Metabolic Profile in Broiler Chickens*](https://doi.org/10.56093/ijans.v87i11.75892)
+
+[8] [David et al. (2024), *Feeding Value of Lupins, Field Peas, Faba Beans and Chickpeas for Poultry*](https://doi.org/10.3390/ani14040619)
+
+[9] [Emiola, Ologhobo & Gous (2007), *Performance and Histological Responses of Internal Organs of Broiler Chickens Fed Raw, Dehulled, and Aqueous and Dry-Heated Kidney Bean Meals*](https://doi.org/10.1093/ps/86.6.1234)

--- a/database/provenance/food-coverage.json
+++ b/database/provenance/food-coverage.json
@@ -110,37 +110,49 @@
           "id": "lentils-raw",
           "displayName": "Lentils",
           "historicalForm": "raw",
-          "linkedFoodReviewKeys": []
+          "linkedFoodReviewKeys": [
+            "lentils::raw dried lentil seeds"
+          ]
         },
         {
           "id": "split-peas-raw",
           "displayName": "Split peas",
           "historicalForm": "raw",
-          "linkedFoodReviewKeys": []
+          "linkedFoodReviewKeys": [
+            "split_peas::raw dried split pea cotyledons"
+          ]
         },
         {
           "id": "mung-beans-raw",
           "displayName": "Mung beans",
           "historicalForm": "raw",
-          "linkedFoodReviewKeys": []
+          "linkedFoodReviewKeys": [
+            "mung_beans::raw dried mung beans"
+          ]
         },
         {
           "id": "chickpeas-raw",
           "displayName": "Chickpeas",
           "historicalForm": "raw",
-          "linkedFoodReviewKeys": ["chickpeas::raw dried seeds"]
+          "linkedFoodReviewKeys": [
+            "chickpeas::raw dried seeds"
+          ]
         },
         {
           "id": "garden-peas-raw",
           "displayName": "Garden peas",
           "historicalForm": "raw",
-          "linkedFoodReviewKeys": []
+          "linkedFoodReviewKeys": [
+            "garden_peas::raw mature dried garden peas"
+          ]
         },
         {
           "id": "kidney-beans-raw",
           "displayName": "Kidney beans",
           "historicalForm": "raw",
-          "linkedFoodReviewKeys": []
+          "linkedFoodReviewKeys": [
+            "kidney_beans::raw dried kidney beans"
+          ]
         },
         {
           "id": "lima-beans-raw",

--- a/database/provenance/food-reviews.json
+++ b/database/provenance/food-reviews.json
@@ -589,7 +589,7 @@
             "melbourne-pet-pigeon-diet-2023",
             "valdes-exotic-insects-2022"
           ],
-          "locator": "Melbourne Bird Veterinary Clinic insect-enrichment context; Vald\u00e9s et al. companion/exotic-pet whole/live/dehydrated insect discussion",
+          "locator": "Melbourne Bird Veterinary Clinic insect-enrichment context; Valdés et al. companion/exotic-pet whole/live/dehydrated insect discussion",
           "evidenceScope": "species_specific",
           "rationale": "The pigeon source permits general insect enrichment context but does not name live yellow mealworm larvae. The broad exotic-pet review cannot supply a pigeon-specific outcome.",
           "reviewedAt": "2026-08-18"
@@ -601,7 +601,7 @@
             "valdes-exotic-insects-2022",
             "merck-psittacines-2025"
           ],
-          "locator": "Vald\u00e9s et al. exotic-pet insect-format discussion; Merck psittacine nutrition and species-variation sections",
+          "locator": "Valdés et al. exotic-pet insect-format discussion; Merck psittacine nutrition and species-variation sections",
           "evidenceScope": "group_specific",
           "rationale": "The review notes generalized exotic-pet use but limited species-specific evidence, and Merck does not establish live mealworms for the general parrot row.",
           "reviewedAt": "2026-08-18"
@@ -613,7 +613,7 @@
             "valdes-exotic-insects-2022",
             "vca-african-grey-feeding"
           ],
-          "locator": "Vald\u00e9s et al. exotic-pet evidence-limit discussion; VCA African Grey balanced-diet guidance",
+          "locator": "Valdés et al. exotic-pet evidence-limit discussion; VCA African Grey balanced-diet guidance",
           "evidenceScope": "species_specific",
           "rationale": "Neither source establishes live yellow mealworm larvae for African Greys or a safe treat amount.",
           "reviewedAt": "2026-08-18"
@@ -625,7 +625,7 @@
             "valdes-exotic-insects-2022",
             "vca-budgie-feeding"
           ],
-          "locator": "Vald\u00e9s et al. exotic-pet insect-format discussion; VCA Budgies feeding guidance",
+          "locator": "Valdés et al. exotic-pet insect-format discussion; VCA Budgies feeding guidance",
           "evidenceScope": "species_specific",
           "rationale": "The reviewed budgie source does not establish live mealworms, and the broad review does not replace species-specific evidence.",
           "reviewedAt": "2026-08-18"
@@ -637,7 +637,7 @@
             "lafeber-canary-mealworms-2020",
             "valdes-exotic-insects-2022"
           ],
-          "locator": "Lafeber canary answer addresses dried mealworms; Vald\u00e9s et al. distinguishes whole/live/dehydrated exotic-pet formats",
+          "locator": "Lafeber canary answer addresses dried mealworms; Valdés et al. distinguishes whole/live/dehydrated exotic-pet formats",
           "evidenceScope": "species_specific",
           "rationale": "Lafeber supports dried mealworms only. It does not establish the submitted live-larva form for canaries.",
           "reviewedAt": "2026-08-18"
@@ -685,7 +685,7 @@
             "melbourne-pet-pigeon-diet-2023",
             "valdes-exotic-insects-2022"
           ],
-          "locator": "Melbourne Bird Veterinary Clinic insect-enrichment context; Vald\u00e9s et al. dehydrated insect discussion",
+          "locator": "Melbourne Bird Veterinary Clinic insect-enrichment context; Valdés et al. dehydrated insect discussion",
           "evidenceScope": "species_specific",
           "rationale": "The pigeon source does not name dried mealworms, and the broad exotic-pet review cannot establish a pigeon-specific dried form outcome.",
           "reviewedAt": "2026-08-18"
@@ -697,7 +697,7 @@
             "valdes-exotic-insects-2022",
             "merck-psittacines-2025"
           ],
-          "locator": "Vald\u00e9s et al. dehydrated insect discussion; Merck psittacine diet and species-variation sections",
+          "locator": "Valdés et al. dehydrated insect discussion; Merck psittacine diet and species-variation sections",
           "evidenceScope": "group_specific",
           "rationale": "The broad review acknowledges exotic-pet insect use but limited species-specific safety evidence. No reviewed source establishes dried mealworms for the general parrot row.",
           "reviewedAt": "2026-08-18"
@@ -709,7 +709,7 @@
             "valdes-exotic-insects-2022",
             "vca-african-grey-feeding"
           ],
-          "locator": "Vald\u00e9s et al. dehydrated insect discussion; VCA African Grey feeding guidance",
+          "locator": "Valdés et al. dehydrated insect discussion; VCA African Grey feeding guidance",
           "evidenceScope": "species_specific",
           "rationale": "No reviewed source establishes dried mealworms for African Greys or a portion boundary.",
           "reviewedAt": "2026-08-18"
@@ -721,7 +721,7 @@
             "valdes-exotic-insects-2022",
             "vca-budgie-feeding"
           ],
-          "locator": "Vald\u00e9s et al. dehydrated insect discussion; VCA Budgies feeding guidance",
+          "locator": "Valdés et al. dehydrated insect discussion; VCA Budgies feeding guidance",
           "evidenceScope": "species_specific",
           "rationale": "The budgie source does not name dried mealworms and the broad review is insufficient for approval.",
           "reviewedAt": "2026-08-18"
@@ -779,7 +779,7 @@
             "melbourne-pet-pigeon-diet-2023",
             "valdes-exotic-insects-2022"
           ],
-          "locator": "Melbourne Bird Veterinary Clinic insect-enrichment context; Vald\u00e9s et al. house-cricket whole/live format discussion",
+          "locator": "Melbourne Bird Veterinary Clinic insect-enrichment context; Valdés et al. house-cricket whole/live format discussion",
           "evidenceScope": "species_specific",
           "rationale": "The pigeon source does not name live commercial crickets, and the broad exotic-pet review does not establish a pigeon-specific outcome.",
           "reviewedAt": "2026-08-18"
@@ -791,7 +791,7 @@
             "valdes-exotic-insects-2022",
             "merck-psittacines-2025"
           ],
-          "locator": "Vald\u00e9s et al. house-cricket whole/live discussion; Merck psittacine diet and species-variation sections",
+          "locator": "Valdés et al. house-cricket whole/live discussion; Merck psittacine diet and species-variation sections",
           "evidenceScope": "group_specific",
           "rationale": "The broad review says exotic-pet use is generalized but species-specific safety evidence is limited; Merck does not establish live crickets for the general parrot row.",
           "reviewedAt": "2026-08-18"
@@ -803,7 +803,7 @@
             "valdes-exotic-insects-2022",
             "vca-african-grey-feeding"
           ],
-          "locator": "Vald\u00e9s et al. house-cricket discussion; VCA African Grey feeding guidance",
+          "locator": "Valdés et al. house-cricket discussion; VCA African Grey feeding guidance",
           "evidenceScope": "species_specific",
           "rationale": "No reviewed source establishes live commercial crickets for African Greys or a portion/form boundary.",
           "reviewedAt": "2026-08-18"
@@ -815,7 +815,7 @@
             "valdes-exotic-insects-2022",
             "vca-budgie-feeding"
           ],
-          "locator": "Vald\u00e9s et al. house-cricket discussion; VCA Budgies feeding guidance",
+          "locator": "Valdés et al. house-cricket discussion; VCA Budgies feeding guidance",
           "evidenceScope": "species_specific",
           "rationale": "The reviewed budgie guidance does not establish live commercial crickets, and the broad exotic-pet review cannot supply that species-specific outcome.",
           "reviewedAt": "2026-08-18"
@@ -827,7 +827,7 @@
             "lafeber-canary-mealworms-2020",
             "valdes-exotic-insects-2022"
           ],
-          "locator": "Lafeber canary answer addresses dried mealworms, not crickets; Vald\u00e9s et al. house-cricket discussion",
+          "locator": "Lafeber canary answer addresses dried mealworms, not crickets; Valdés et al. house-cricket discussion",
           "evidenceScope": "species_specific",
           "rationale": "The canary-specific source supports dried mealworms only, so it does not establish live commercial crickets.",
           "reviewedAt": "2026-08-18"
@@ -850,6 +850,468 @@
           "valdes-exotic-insects-2022"
         ],
         "rule": "Use only clean, commercially controlled live crickets of an appropriate size; keep wild-caught insects, dried crickets, cricket meal, gut-loading diets, and pesticide exposure as distinct forms and risk questions. Never treat insects alone as a complete ration.",
+        "severity": "warning"
+      },
+      "lastReviewedAt": "2026-08-18"
+    },
+    {
+      "ingredientId": "lentils",
+      "ingredientDisplayName": "Lentils",
+      "form": "raw dried lentil seeds",
+      "nutrition": {
+        "sourceIds": [
+          "ciurescu-2017-raw-lentil-broilers"
+        ],
+        "basis": "not_applicable",
+        "notes": "Evidence-only review of the raw dried lentil form. It does not add a nutrient value, a dry-mix instruction, or a complete-ration claim."
+      },
+      "speciesEvidence": [
+        {
+          "bird": "pigeon",
+          "outcome": "limited",
+          "sourceIds": [
+            "pigeon-guide-diet-2026"
+          ],
+          "locator": "Pigeon Diet Guide ‘Treats’ and ‘Mixing Your Own Feed’ sections naming dried lentils",
+          "evidenceScope": "species_specific",
+          "rationale": "Pigeon-specific owner guidance names dried lentils in feed/treat context. Its reference section is empty and it provides no raw-legume safety, portion, or nutrition rule, so this is limited context only and not a formula or runtime approval.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "parrot",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "petcraft-parrot-beans-2014"
+          ],
+          "locator": "Petcraft opening pulse paragraph and list explicitly naming lentils among pulses that must be cooked",
+          "evidenceScope": "group_specific",
+          "rationale": "Parrot-focused guidance explicitly names lentils among pulses that must be cooked. This establishes a preparation boundary only; it does not prescribe a method, portion, complete ration, or result for another species.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "african_grey",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "vca-african-grey-feeding"
+          ],
+          "locator": "VCA African Grey suggested-food table, which separately lists lentils and ‘cooked beans (various types)’",
+          "evidenceScope": "species_specific",
+          "rationale": "Grey-specific veterinary guidance lists lentils within a table that separately identifies cooked beans. The raw dried form therefore requires preparation before any Grey use; no portion, recipe, formula, or unrestricted approval is established.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "budgie",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "vca-budgie-feeding"
+          ],
+          "locator": "VCA Budgies suitable-food table listing ‘cooked beans (various)’ and its balanced-diet guidance",
+          "evidenceScope": "species_specific",
+          "rationale": "Budgie-specific veterinary guidance identifies cooked beans, not raw dried lentils. This supports a preparation requirement only; it does not establish a method, portion, formula use, or complete ration.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "canary",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "vca-canary-feeding"
+          ],
+          "locator": "VCA Canaries ‘Fruits, vegetables, and legumes suitable for canaries include’ table, where lentils are under ‘cooked beans’",
+          "evidenceScope": "species_specific",
+          "rationale": "Canary-specific veterinary guidance explicitly lists lentils under cooked beans, not as raw dried food. This supports a preparation requirement only and does not establish a portion, formula use, or complete ration.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "chicken",
+          "outcome": "limited",
+          "sourceIds": [
+            "ciurescu-2017-raw-lentil-broilers"
+          ],
+          "locator": "Ciurescu et al. abstract: Cobb 500 broilers, raw lentil seed at 200 or 400 g/kg in balanced experimental diets",
+          "evidenceScope": "species_specific",
+          "rationale": "Direct broiler evidence concerns raw lentil seed in specified balanced experimental rations. It supports only the studied chicken/ration context and does not establish unsupervised household feeding, a universal inclusion rate, or another species outcome.",
+          "reviewedAt": "2026-08-18"
+        }
+      ],
+      "processing": {
+        "sourceIds": [
+          "petcraft-parrot-beans-2014",
+          "vca-african-grey-feeding",
+          "vca-budgie-feeding",
+          "vca-canary-feeding",
+          "ciurescu-2017-raw-lentil-broilers"
+        ],
+        "rule": "Keep raw dried lentil seeds distinct from cooked lentils, sprouted lentils, lentil flour, and lentil products. Companion-bird records require preparation; chicken evidence is limited to the cited balanced broiler-ration context; pigeon evidence is limited uncited owner guidance. This record does not approve runtime use, a formula, a portion, or a complete ration.",
+        "severity": "warning"
+      },
+      "lastReviewedAt": "2026-08-18"
+    },
+    {
+      "ingredientId": "split_peas",
+      "ingredientDisplayName": "Split peas",
+      "form": "raw dried split pea cotyledons",
+      "nutrition": {
+        "sourceIds": [
+          "david-poultry-legumes-2024"
+        ],
+        "basis": "not_applicable",
+        "notes": "Evidence-only review of unheated dried split pea cotyledons. It does not add a nutrient value, a dry-mix instruction, or a complete-ration claim."
+      },
+      "speciesEvidence": [
+        {
+          "bird": "pigeon",
+          "outcome": "limited",
+          "sourceIds": [
+            "pigeon-guide-diet-2026"
+          ],
+          "locator": "Pigeon Diet Guide ‘Mixing Your Own Feed’ section naming dried lentils and split peas",
+          "evidenceScope": "species_specific",
+          "rationale": "Pigeon-specific owner guidance names split peas as a dried feed-mix addition. It provides no raw-legume preparation or inclusion-rate evidence, so this supports limited named-ingredient context only.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "parrot",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "petcraft-parrot-beans-2014"
+          ],
+          "locator": "Petcraft opening pulse paragraph and list explicitly naming yellow and green split peas among pulses that must be cooked",
+          "evidenceScope": "group_specific",
+          "rationale": "Parrot-focused guidance explicitly names yellow and green split peas among pulses that must be cooked. This is a preparation boundary only, not a portion, formula, runtime approval, or another-species conclusion.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "african_grey",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "vca-african-grey-feeding"
+          ],
+          "locator": "VCA African Grey suggested-food table’s ‘cooked beans (various types)’ entry and balanced-diet guidance",
+          "evidenceScope": "species_specific",
+          "rationale": "Grey-specific veterinary guidance identifies cooked beans rather than an unheated dried split-pea form. This supports a preparation requirement only; no raw form, portion, recipe, formula, or complete ration is established.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "budgie",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "vca-budgie-feeding"
+          ],
+          "locator": "VCA Budgies suitable-food table’s ‘cooked beans (various)’ entry and balanced-diet guidance",
+          "evidenceScope": "species_specific",
+          "rationale": "Budgie-specific veterinary guidance identifies cooked beans rather than an unheated dried split-pea form. This supports a preparation requirement only; no raw form, portion, formula use, or complete ration is established.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "canary",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "vca-canary-feeding"
+          ],
+          "locator": "VCA Canaries cooked-bean entry and suitable-food table naming peas",
+          "evidenceScope": "species_specific",
+          "rationale": "Canary-specific veterinary guidance distinguishes cooked beans and separately names peas. It does not establish raw dried split peas; this conservative record requires preparation and does not establish portion, formula use, or a complete ration.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "chicken",
+          "outcome": "limited",
+          "sourceIds": [
+            "david-poultry-legumes-2024"
+          ],
+          "locator": "David et al. abstract and field-pea poultry-feed sections",
+          "evidenceScope": "species_specific",
+          "rationale": "The poultry review addresses dry field peas and antinutritional-factor/formulation boundaries in poultry feed. This is limited chicken feed-context evidence only; it does not establish home feeding, a complete ration, or another species outcome.",
+          "reviewedAt": "2026-08-18"
+        }
+      ],
+      "processing": {
+        "sourceIds": [
+          "petcraft-parrot-beans-2014",
+          "vca-african-grey-feeding",
+          "vca-budgie-feeding",
+          "vca-canary-feeding",
+          "david-poultry-legumes-2024"
+        ],
+        "rule": "Keep raw dried split pea cotyledons distinct from whole dry field peas, fresh garden peas, cooked peas, and sprouts. Companion-bird records require preparation; chicken evidence is limited to poultry feed formulation; pigeon evidence is limited uncited owner guidance. This record does not approve runtime use, a formula, a portion, or a complete ration.",
+        "severity": "warning"
+      },
+      "lastReviewedAt": "2026-08-18"
+    },
+    {
+      "ingredientId": "mung_beans",
+      "ingredientDisplayName": "Mung beans",
+      "form": "raw dried mung beans",
+      "nutrition": {
+        "sourceIds": [
+          "ftb-legume-safety-2018"
+        ],
+        "basis": "not_applicable",
+        "notes": "Evidence-only review of the raw dried mung-bean form. It does not add a nutrient value, a dry-mix instruction, or a complete-ration claim."
+      },
+      "speciesEvidence": [
+        {
+          "bird": "pigeon",
+          "outcome": "limited",
+          "sourceIds": [
+            "pigeon-guide-diet-2026"
+          ],
+          "locator": "Pigeon Diet Guide ‘Treats’ section naming mung beans",
+          "evidenceScope": "species_specific",
+          "rationale": "Pigeon-specific owner guidance names mung beans as treats, but does not specify form, preparation, portion, or a citation trail. This is limited ingredient context only and not an approval of raw dried use, a formula, or a runtime outcome.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "parrot",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "ftb-legume-safety-2018"
+          ],
+          "locator": "For the Birds ‘There are a few varieties of beans that are okay to sprout’ paragraph naming mung bean",
+          "evidenceScope": "group_specific",
+          "rationale": "Parrot-rescue guidance identifies mung bean as sproutable, which establishes a preparation boundary rather than raw dried use. It does not prescribe a sprouting protocol, portion, complete ration, runtime approval, or another species outcome.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "african_grey",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "vca-african-grey-feeding"
+          ],
+          "locator": "VCA African Grey suggested-food table’s ‘cooked beans (various types)’ entry and balanced-diet guidance",
+          "evidenceScope": "species_specific",
+          "rationale": "Grey-specific veterinary guidance identifies cooked beans rather than raw dried mung beans. This supports a preparation requirement only; no raw form, portion, formula use, or complete ration is established.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "budgie",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "vca-budgie-feeding"
+          ],
+          "locator": "VCA Budgies suitable-food table’s ‘cooked beans (various)’ entry and balanced-diet guidance",
+          "evidenceScope": "species_specific",
+          "rationale": "Budgie-specific veterinary guidance identifies cooked beans rather than raw dried mung beans. This supports a preparation requirement only; no raw form, portion, formula use, or complete ration is established.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "canary",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "vca-canary-feeding"
+          ],
+          "locator": "VCA Canaries suitable-food table listing mung under ‘cooked beans’",
+          "evidenceScope": "species_specific",
+          "rationale": "Canary-specific veterinary guidance explicitly lists mung under cooked beans, not raw dried food. This supports a preparation requirement only and does not establish a portion, formula use, or complete ration.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "chicken",
+          "outcome": "unresolved",
+          "sourceIds": [
+            "merck-poultry-2024"
+          ],
+          "locator": "Merck Nutritional Requirements of Poultry nutrient-balance and complete-ration sections",
+          "evidenceScope": "species_specific",
+          "rationale": "A targeted search identified mung-bean broiler studies but accessible full text could not be verified; Merck establishes only the complete-ration boundary and does not identify raw dried mung bean. The chicken raw-mung record therefore remains unresolved rather than relying on snippets or cross-legume inference.",
+          "reviewedAt": "2026-08-18"
+        }
+      ],
+      "processing": {
+        "sourceIds": [
+          "ftb-legume-safety-2018",
+          "vca-african-grey-feeding",
+          "vca-budgie-feeding",
+          "vca-canary-feeding",
+          "merck-poultry-2024"
+        ],
+        "rule": "Keep raw dried mung beans distinct from sprouted mung beans, cooked mung beans, mung flour, and residues. Companion-bird records require preparation; chicken remains unresolved pending accessible direct raw-mung chicken evidence; pigeon evidence is limited uncited owner guidance. This record does not approve runtime use, a formula, a portion, or a complete ration.",
+        "severity": "warning"
+      },
+      "lastReviewedAt": "2026-08-18"
+    },
+    {
+      "ingredientId": "garden_peas",
+      "ingredientDisplayName": "Garden peas",
+      "form": "raw mature dried garden peas",
+      "nutrition": {
+        "sourceIds": [
+          "david-poultry-legumes-2024"
+        ],
+        "basis": "not_applicable",
+        "notes": "Evidence-only review of raw mature dried garden peas. It does not add a nutrient value, a dry-mix instruction, or a complete-ration claim."
+      },
+      "speciesEvidence": [
+        {
+          "bird": "pigeon",
+          "outcome": "limited",
+          "sourceIds": [
+            "pigeon-guide-diet-2026"
+          ],
+          "locator": "Pigeon Diet Guide opening diet paragraph naming dried peas and ‘Treats’ paragraph naming peas",
+          "evidenceScope": "species_specific",
+          "rationale": "Pigeon-specific owner guidance names dried peas and peas in feed/treat context. It lacks a preparation, portion, and citation trail, so this supports limited named-ingredient context only and not a formula or runtime approval.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "parrot",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "ftb-legume-safety-2018"
+          ],
+          "locator": "For the Birds sproutable-beans paragraph naming ‘Peas (sweet or green)’",
+          "evidenceScope": "group_specific",
+          "rationale": "Parrot-rescue guidance identifies sweet/green peas as sproutable, establishing a preparation boundary rather than approval of a raw mature dried form. It does not prescribe a process, portion, complete ration, runtime approval, or another species outcome.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "african_grey",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "vca-african-grey-feeding"
+          ],
+          "locator": "VCA African Grey suggested-food table naming peas and separately listing ‘cooked beans (various types)’",
+          "evidenceScope": "species_specific",
+          "rationale": "Grey-specific veterinary guidance names peas in fresh-food context and identifies cooked beans. It does not establish raw mature dried garden peas; this conservative record requires preparation and does not establish a portion, formula use, or complete ration.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "budgie",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "vca-budgie-feeding"
+          ],
+          "locator": "VCA Budgies suitable-food table naming peas and ‘cooked beans (various)’",
+          "evidenceScope": "species_specific",
+          "rationale": "Budgie-specific veterinary guidance names peas and cooked beans, not raw mature dried garden peas. This supports a preparation requirement only; no raw form, portion, formula use, or complete ration is established.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "canary",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "vca-canary-feeding"
+          ],
+          "locator": "VCA Canaries suitable-food table naming peas and cooked beans",
+          "evidenceScope": "species_specific",
+          "rationale": "Canary-specific veterinary guidance names peas and cooked beans, not raw mature dried garden peas. This supports a preparation requirement only and does not establish a portion, formula use, or complete ration.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "chicken",
+          "outcome": "limited",
+          "sourceIds": [
+            "david-poultry-legumes-2024"
+          ],
+          "locator": "David et al. abstract, grain-legume classification, and field-pea poultry feeding sections",
+          "evidenceScope": "species_specific",
+          "rationale": "The poultry review addresses dry field peas and feed formulation with antinutritional-factor boundaries. This is limited chicken feed-context evidence only; it does not establish household feeding, a complete ration, or another species outcome.",
+          "reviewedAt": "2026-08-18"
+        }
+      ],
+      "processing": {
+        "sourceIds": [
+          "ftb-legume-safety-2018",
+          "vca-african-grey-feeding",
+          "vca-budgie-feeding",
+          "vca-canary-feeding",
+          "david-poultry-legumes-2024"
+        ],
+        "rule": "Keep raw mature dried garden peas distinct from fresh green peas, split peas, cooked peas, and sprouts. Companion-bird records require preparation; chicken evidence is limited to dry field-pea feed formulation; pigeon evidence is limited uncited owner guidance. This record does not approve runtime use, a formula, a portion, or a complete ration.",
+        "severity": "warning"
+      },
+      "lastReviewedAt": "2026-08-18"
+    },
+    {
+      "ingredientId": "kidney_beans",
+      "ingredientDisplayName": "Kidney beans",
+      "form": "raw dried kidney beans",
+      "nutrition": {
+        "sourceIds": [
+          "emiola-2007-raw-kidney-bean-broilers"
+        ],
+        "basis": "not_applicable",
+        "notes": "Evidence-only review of the raw dried kidney-bean form. It does not add a nutrient value, a dry-mix instruction, or a complete-ration claim."
+      },
+      "speciesEvidence": [
+        {
+          "bird": "pigeon",
+          "outcome": "unresolved",
+          "sourceIds": [
+            "vca-pigeon-dove-feeding"
+          ],
+          "locator": "VCA ‘Can I feed people food to my pigeon or dove?’ section",
+          "evidenceScope": "species_specific",
+          "rationale": "The pigeon-specific veterinary source gives general human-food context but does not name kidney beans, raw beans, or a preparation boundary. Targeted pigeon searches returned inaccessible social posts and conflicting unverified community claims, so this raw kidney-bean record remains unresolved rather than inferring from chicken or parrot sources.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "parrot",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "ftb-legume-safety-2018",
+            "petcraft-parrot-beans-2014"
+          ],
+          "locator": "For the Birds kidney-bean paragraph requiring full cooking; Petcraft opening pulse paragraph requiring cooking",
+          "evidenceScope": "group_specific",
+          "rationale": "Parrot-focused guidance explicitly says kidney beans should be fully cooked and more broadly directs that pulses be cooked. This establishes a preparation boundary only, not a method, portion, formula use, complete ration, runtime approval, or another species outcome.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "african_grey",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "vca-african-grey-feeding"
+          ],
+          "locator": "VCA African Grey suggested-food table’s ‘cooked beans (various types)’ entry and balanced-diet guidance",
+          "evidenceScope": "species_specific",
+          "rationale": "Grey-specific veterinary guidance identifies cooked beans rather than raw dried kidney beans. This supports a preparation requirement only; no raw form, portion, formula use, or complete ration is established.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "budgie",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "vca-budgie-feeding"
+          ],
+          "locator": "VCA Budgies suitable-food table’s ‘cooked beans (various)’ entry and balanced-diet guidance",
+          "evidenceScope": "species_specific",
+          "rationale": "Budgie-specific veterinary guidance identifies cooked beans rather than raw dried kidney beans. This supports a preparation requirement only; no raw form, portion, formula use, or complete ration is established.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "canary",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "vca-canary-feeding"
+          ],
+          "locator": "VCA Canaries suitable-food table listing kidney under ‘cooked beans’",
+          "evidenceScope": "species_specific",
+          "rationale": "Canary-specific veterinary guidance explicitly lists kidney under cooked beans, not raw dried food. This supports a preparation requirement only and does not establish a portion, formula use, or complete ration.",
+          "reviewedAt": "2026-08-18"
+        },
+        {
+          "bird": "chicken",
+          "outcome": "requires_preparation",
+          "sourceIds": [
+            "emiola-2007-raw-kidney-bean-broilers"
+          ],
+          "locator": "Emiola et al. abstract: raw/dehulled kidney-bean meals, broiler performance and internal-organ histology; aqueous-heated meal result",
+          "evidenceScope": "species_specific",
+          "rationale": "Direct broiler evidence found poorer performance and reported pancreatic, kidney, and liver changes with raw/dehulled kidney-bean meals, while aqueous-heated meal did not show the reported adverse effects in that trial. This establishes a chicken preparation boundary only; it does not prescribe a household method, formula, portion, or another species outcome.",
+          "reviewedAt": "2026-08-18"
+        }
+      ],
+      "processing": {
+        "sourceIds": [
+          "ftb-legume-safety-2018",
+          "petcraft-parrot-beans-2014",
+          "vca-african-grey-feeding",
+          "vca-budgie-feeding",
+          "vca-canary-feeding",
+          "emiola-2007-raw-kidney-bean-broilers"
+        ],
+        "rule": "Keep raw dried kidney beans distinct from fully cooked, sprouted, canned, flour, or processed forms. Companion-bird and chicken records require preparation; pigeon remains unresolved pending direct pigeon-specific evidence. This record does not approve runtime use, a formula, a portion, or a complete ration.",
         "severity": "warning"
       },
       "lastReviewedAt": "2026-08-18"

--- a/database/provenance/sources.json
+++ b/database/provenance/sources.json
@@ -600,7 +600,7 @@
     {
       "id": "valdes-exotic-insects-2022",
       "title": "Insects as Feed for Companion and Exotic Pets: A Current Trend",
-      "authorsOrOrganization": "Fabrizzio Vald\u00e9s; Valeria Villanueva; Emerson Dur\u00e1n; Francisca Campos; Constanza Avenda\u00f1o; Manuel S\u00e1nchez; Chaneta Domingoz-Araujo; Carolina Valenzuela",
+      "authorsOrOrganization": "Fabrizzio Valdés; Valeria Villanueva; Emerson Durán; Francisca Campos; Constanza Avendaño; Manuel Sánchez; Chaneta Domingoz-Araujo; Carolina Valenzuela",
       "publishedYear": "2022",
       "sourceTier": "peer_reviewed_review",
       "urlOrDoi": "https://doi.org/10.3390/ani12111450",
@@ -640,6 +640,80 @@
       ],
       "permittedUse": "Controlled broiler study of limited live yellow mealworm larvae as environmental enrichment alongside a commercial diet.",
       "limitations": "Broiler strain, age, quantity, and study conditions are specific; it cannot establish pet-bird outcomes or a general mealworm feeding amount.",
+      "accessedAt": "2026-08-18"
+    },
+    {
+      "id": "pigeon-guide-diet-2026",
+      "title": "Pigeon Diet Guide",
+      "authorsOrOrganization": "CPC Staff; Columbidae Ownership Omnibus",
+      "publishedYear": "2026",
+      "sourceTier": "owner_guidance_with_citations",
+      "urlOrDoi": "https://www.pigeon.guide/Pigeon-Diet-Guide-f696d4f98d994603b367803aba5f0ce8",
+      "speciesScopes": [
+        "pigeon"
+      ],
+      "permittedUse": "Pigeon-specific owner guidance naming dried lentils, split peas, mung beans, and dried peas as feed-mix or treat context.",
+      "limitations": "Community guidance with an empty references section. It does not establish raw-legume safety, preparation, portion, nutrient values, formula inclusion, or kidney-bean use; it supports only the exact named pigeon ingredient context.",
+      "accessedAt": "2026-08-18"
+    },
+    {
+      "id": "petcraft-parrot-beans-2014",
+      "title": "Cooking Beans for Parrots",
+      "authorsOrOrganization": "David Poole; Petcraft",
+      "publishedYear": "2014",
+      "sourceTier": "owner_guidance_with_citations",
+      "urlOrDoi": "https://www.petcraft.com/articles/2014/10/12/cooking-beans-for-parrots/",
+      "speciesScopes": [
+        "parrot",
+        "psittacine"
+      ],
+      "permittedUse": "Parrot-focused preparation context explicitly naming lentils and yellow/green split peas as pulses to cook before offering.",
+      "limitations": "Owner guidance, not a controlled feeding study. It does not establish a species-specific dose, a universal cooking protocol, a complete ration, runtime approval, or an outcome for pigeons, African Greys, budgies, canaries, or chickens.",
+      "accessedAt": "2026-08-18"
+    },
+    {
+      "id": "ftb-legume-safety-2018",
+      "title": "Legume Safety Warning",
+      "authorsOrOrganization": "Shauna Roberts; For the Birds Parrot Rescue & Sanctuary",
+      "publishedYear": "2018",
+      "sourceTier": "owner_guidance_with_citations",
+      "urlOrDoi": "https://www.ftbrescue.com/post/2018/01/13/legume-safety-warning",
+      "speciesScopes": [
+        "parrot",
+        "psittacine"
+      ],
+      "permittedUse": "Parrot-rescue preparation guidance that identifies lentils, mung beans, and sweet/green peas as sproutable and says kidney beans should be fully cooked.",
+      "limitations": "Rescue owner guidance, not a controlled feeding trial. It does not establish a preparation method, portion, complete ration, runtime approval, or outcome for pigeons, African Greys, budgies, canaries, or chickens.",
+      "accessedAt": "2026-08-18"
+    },
+    {
+      "id": "ciurescu-2017-raw-lentil-broilers",
+      "title": "Beneficial Effects of Increasing Dietary Levels of Raw Lentil Seeds on Meat Fatty Acid and Plasma Metabolic Profile in Broiler Chickens",
+      "authorsOrOrganization": "Georgeta Ciurescu; Andreea Vasilachi; Mariana Ropotă; Mihai Palade; Cătălin Dragomir",
+      "publishedYear": "2017",
+      "sourceTier": "primary",
+      "urlOrDoi": "https://doi.org/10.56093/ijans.v87i11.75892",
+      "speciesScopes": [
+        "chicken",
+        "broiler_chicken"
+      ],
+      "permittedUse": "Controlled Cobb 500 broiler evidence for raw lentil seed within specified balanced experimental diets at stated inclusion levels.",
+      "limitations": "Broiler production study only; it does not establish household feeding, a universal inclusion rate, a complete ration, or an outcome for pigeons, psittacines, budgies, canaries, or another legume form.",
+      "accessedAt": "2026-08-18"
+    },
+    {
+      "id": "emiola-2007-raw-kidney-bean-broilers",
+      "title": "Performance and Histological Responses of Internal Organs of Broiler Chickens Fed Raw, Dehulled, and Aqueous and Dry-Heated Kidney Bean Meals",
+      "authorsOrOrganization": "I. A. Emiola; A. D. Ologhobo; R. M. Gous",
+      "publishedYear": "2007",
+      "sourceTier": "primary",
+      "urlOrDoi": "https://doi.org/10.1093/ps/86.6.1234",
+      "speciesScopes": [
+        "chicken",
+        "broiler_chicken"
+      ],
+      "permittedUse": "Controlled 56-day broiler evidence comparing raw and processed kidney-bean meals within stated experimental diets and documenting the reported performance and organ-histology boundary.",
+      "limitations": "Broiler production study only; it does not prescribe a household preparation method, a complete ration, or an outcome for pigeons, psittacines, budgies, canaries, or another legume form.",
       "accessedAt": "2026-08-18"
     }
   ]

--- a/v3-webapp/client/src/lib/provenance-ledger.test.ts
+++ b/v3-webapp/client/src/lib/provenance-ledger.test.ts
@@ -107,6 +107,75 @@ describe("canonical provenance ledger", () => {
     expect(rawChickpeaCoverage?.linkedFoodReviewKeys).toEqual(["chickpeas::raw dried seeds"]);
   });
 
+  it("records the five-item raw-legume batch with complete six-bird evidence and coverage links", () => {
+    const foodLedger = readJson("food-reviews.json") as {
+      requiredBirdOrder: string[];
+      ingredientReviews: Array<{
+        ingredientId: string;
+        form: string;
+        speciesEvidence: Array<{ bird: string; outcome: string; sourceIds: string[] }>;
+      }>;
+    };
+    const coverageLedger = readJson("food-coverage.json") as {
+      claimCoverage: Array<{
+        historicalClaimId: string;
+        trackedItems: Array<{ id: string; linkedFoodReviewKeys: string[] }>;
+      }>;
+    };
+    const expected = [
+      {
+        trackedItemId: "lentils-raw",
+        ingredientId: "lentils",
+        form: "raw dried lentil seeds",
+        outcomes: ["limited", "requires_preparation", "requires_preparation", "requires_preparation", "requires_preparation", "limited"],
+      },
+      {
+        trackedItemId: "split-peas-raw",
+        ingredientId: "split_peas",
+        form: "raw dried split pea cotyledons",
+        outcomes: ["limited", "requires_preparation", "requires_preparation", "requires_preparation", "requires_preparation", "limited"],
+      },
+      {
+        trackedItemId: "mung-beans-raw",
+        ingredientId: "mung_beans",
+        form: "raw dried mung beans",
+        outcomes: ["limited", "requires_preparation", "requires_preparation", "requires_preparation", "requires_preparation", "unresolved"],
+      },
+      {
+        trackedItemId: "garden-peas-raw",
+        ingredientId: "garden_peas",
+        form: "raw mature dried garden peas",
+        outcomes: ["limited", "requires_preparation", "requires_preparation", "requires_preparation", "requires_preparation", "limited"],
+      },
+      {
+        trackedItemId: "kidney-beans-raw",
+        ingredientId: "kidney_beans",
+        form: "raw dried kidney beans",
+        outcomes: ["unresolved", "requires_preparation", "requires_preparation", "requires_preparation", "requires_preparation", "requires_preparation"],
+      },
+    ];
+    const rawLegumeCoverage = coverageLedger.claimCoverage.find(
+      (coverage) => coverage.historicalClaimId === "historical-raw-legume-rules",
+    );
+
+    for (const expectedReview of expected) {
+      const review = foodLedger.ingredientReviews.find(
+        (candidate) =>
+          candidate.ingredientId === expectedReview.ingredientId && candidate.form === expectedReview.form,
+      );
+      const trackedItem = rawLegumeCoverage?.trackedItems.find(
+        (item) => item.id === expectedReview.trackedItemId,
+      );
+
+      expect(review?.speciesEvidence.map((entry) => entry.bird)).toEqual(foodLedger.requiredBirdOrder);
+      expect(review?.speciesEvidence.map((entry) => entry.outcome)).toEqual(expectedReview.outcomes);
+      expect(review?.speciesEvidence.every((entry) => entry.sourceIds.length > 0)).toBe(true);
+      expect(trackedItem?.linkedFoodReviewKeys).toEqual([
+        `${expectedReview.ingredientId}::${expectedReview.form}`,
+      ]);
+    }
+  });
+
   it("records each new food/form review with six birds and expected outcomes", () => {
     const ledger = readJson("food-reviews.json") as {
       requiredBirdOrder: string[];


### PR DESCRIPTION
## Summary

Relates to #92.

This is a substantive **five-item** provenance batch for the protected historical raw-legume backlog. It adds complete, explicit six-bird reviews for:

| Historical item | Recorded food/form | Resulting coverage status |
| --- | --- | --- |
| Lentils | Raw dried lentil seeds | Complete six-bird record linked |
| Split peas | Raw dried split pea cotyledons | Complete six-bird record linked |
| Mung beans | Raw dried mung beans | Complete six-bird record linked |
| Garden peas | Raw mature dried garden peas | Complete six-bird record linked |
| Kidney beans | Raw dried kidney beans | Complete six-bird record linked |

The Issue #92 coverage report moves from **1** to **6** linked complete raw-legume reviews and from **28** to **23** tracked items awaiting a complete six-bird review.

## Evidence boundaries

The batch uses direct pigeon owner guidance, direct parrot/canary/budgie/African-Grey feeding guidance, and chicken feed studies where available. It does not derive one bird’s suitability from another bird’s evidence.

* Raw lentils, split peas, mung beans, and raw mature dried garden peas have limited pigeon ingredient-context records; companion-bird rows are preparation-bound; chicken evidence is limited to feed-study/formulation context where directly sourced.
* Raw kidney beans are preparation-bound for parrot, African Grey, budgie, canary, and chicken. The direct broiler study documents adverse raw/dehulled kidney-bean findings and the different aqueous-heated study condition.
* **Pigeon raw kidney beans remain unresolved** after targeted pigeon-specific research did not yield a citable direct source.
* **Chicken raw mung beans remain unresolved** because candidate broiler studies could not be accessed and verified in full; no search snippet was promoted to evidence.

The canonical evidence note is `database/provenance/evidence/raw-legume-batch-1.md`.

## Validation

Validated on this branch:

- `pnpm test:provenance` — provenance validator and 9 provenance tests pass.
- `pnpm report:provenance-food-coverage` — reports 6/29 tracked items linked to complete six-bird reviews and 23 remaining.
- `pnpm --dir v3-webapp exec vitest run src/lib/provenance-ledger.test.ts` — 9 tests pass.
- `pnpm run check` — TypeScript check passes.
- `pnpm run test:calculator` — 21 scenarios pass.
- `pnpm run test:herb-safety` — 26 records across six bird types pass.
- `pnpm run test:inventory-presets` and `pnpm run test:profile-default-formulas` — pass.
- `pnpm run build` — production build passes.
- `git diff --check` — passes.

The production build emitted only existing optional analytics-variable and chunk-size warnings; no validation failed.

## What did not change

This PR does **not** alter runtime food eligibility, active inventory options, calculator outputs, formulas, nutrient values, recommendations, toxicity or raw-adzuki warnings, preparation copy, public-facing wording, Firebase configuration, Firestore region, deployment, or local worktrees. There are **no visitor-visible copy changes**.

## Requested owner decision

Please review the source boundaries—especially the retained pigeon/kidney-bean and chicken/mung-bean evidence gaps—and approve this batch for merge only if you agree that it is a documentation-only five-item increment. It intentionally does **not** close Issue #92, because 23 tracked food/form reviews remain.
