### PR TITLE
docs(provenance): add six-bird walnut evidence ledger

### DIFF
--- a/database/provenance/food-reviews.json
+++ b/database/provenance/food-reviews.json
@@ -1785,8 +1785,20 @@
           ],
           "locator": "Veterinarian answer: pigeons cannot masticate and nut pieces should be chopped to small-seed size",
           "evidenceScope": "species_specific",
-          "rationale": "The pigeon-specific source establishes a mechanical-size boundary for cashew pieces, not walnut suitability. No direct pigeon walnut source was found, so walnut remains unresolved rather than being inferred from parrot or poultry evidence.",
-          "reviewedAt": "2026-08-19"
+          "rationale": "The pigeon-specific source establishes a mechanical-size boundary for cashew pieces, not walnut suitability. No direct pigeon walnut source was found, so walnut remains unresolved rather than being inferred from parrot or poultry evidence. A documented second targeted search was completed; its queries and result are recorded in followUpSearch.",
+          "reviewedAt": "2026-08-19",
+          "followUpSearch": {
+            "queries": [
+              "pigeon walnut chopped small seed veterinary",
+              "pigeon walnut kernel raw unsalted feeding",
+              "Taube Walnusskerne Fütterung"
+            ],
+            "sourceIds": [
+              "vca-pigeon-dove-feeding",
+              "petco-pigeon-cashew-preparation-2019"
+            ],
+            "result": "VCA pigeon/dove guidance confirms tiny manageable pieces and small quantities for produce/people food but does not name walnut. Community and German results were not authoritative direct walnut evidence; the exact walnut outcome remains unresolved."
+          }
         },
         {
           "bird": "parrot",
@@ -1797,8 +1809,19 @@
           ],
           "locator": "Lafeber walnut-nutrition answer; Feedipedia kernel composition and rancidity sections",
           "evidenceScope": "group_specific",
-          "rationale": "Lafeber directly supports small walnut pieces as an occasional Amazon-parrot reward within a predominantly complete diet. Feedipedia supports treating walnut kernel as a high-fat, freshness-sensitive food. This supports limited companion-parrot use only and does not approve a dry-mix ingredient, universal portion, or roasted form.",
-          "reviewedAt": "2026-08-19"
+          "rationale": "Lafeber directly supports small walnut pieces as an occasional Amazon-parrot reward within a predominantly complete diet. Feedipedia supports treating walnut kernel as a high-fat, freshness-sensitive food. This supports limited companion-parrot use only and does not approve a dry-mix ingredient, universal portion, or roasted form. A documented second targeted search was completed; its queries and result are recorded in followUpSearch.",
+          "reviewedAt": "2026-08-19",
+          "followUpSearch": {
+            "queries": [
+              "parrot walnut raw dry roasted unsalted veterinary",
+              "Papagei Walnüsse ungesalzen"
+            ],
+            "sourceIds": [
+              "lafeber-nut-meats-2026",
+              "lafeber-walnut-nutrition-2020"
+            ],
+            "result": "Lafeber’s Meyer-parrot guidance names walnuts, prefers raw nuts, accepts dry-roasted unsalted nuts in moderation, rejects oil-roasted nuts, and limits nuts to a small dietary share. This strengthens the limited parrot outcome."
+          }
         },
         {
           "bird": "african_grey",
@@ -1809,8 +1832,18 @@
           ],
           "locator": "VCA African Grey 'Seeds' section naming walnuts among occasional tree nuts; Feedipedia kernel composition and freshness sections",
           "evidenceScope": "species_specific",
-          "rationale": "VCA explicitly names walnuts among the couple of tree nuts that may be offered daily to an African Grey while pellets remain the diet base, and warns about obesity and high-fat diets. Feedipedia supports the high-fat and freshness boundary. This is limited treat guidance, not formula inclusion or an unrestricted raw/roasted approval.",
-          "reviewedAt": "2026-08-19"
+          "rationale": "VCA explicitly names walnuts among the couple of tree nuts that may be offered daily to an African Grey while pellets remain the diet base, and warns about obesity and high-fat diets. Feedipedia supports the high-fat and freshness boundary. This is limited treat guidance, not formula inclusion or an unrestricted raw/roasted approval. A documented second targeted search was completed; its queries and result are recorded in followUpSearch.",
+          "reviewedAt": "2026-08-19",
+          "followUpSearch": {
+            "queries": [
+              "African Grey walnut raw unsalted veterinarian",
+              "Graupapagei Walnüsse ungesalzen Fütterung"
+            ],
+            "sourceIds": [
+              "vca-african-grey-feeding"
+            ],
+            "result": "VCA again directly names walnuts among occasional tree nuts for African Greys. Other results were keeper or retail guidance, so the outcome remains limited rather than unrestricted."
+          }
         },
         {
           "bird": "budgie",
@@ -1821,8 +1854,19 @@
           ],
           "locator": "VCA Budgies feeding sections on obesity, high-fat foods, tiny human-food portions, and avoidance of butter/oil-cooked foods; Feedipedia kernel composition",
           "evidenceScope": "species_specific",
-          "rationale": "Budgie-specific veterinary guidance establishes obesity, high-fat, and preparation boundaries but does not name walnut. Feedipedia identifies walnut kernel as fat-rich. These sources do not establish a walnut outcome, so no cross-species inference is made.",
-          "reviewedAt": "2026-08-19"
+          "rationale": "Budgie-specific veterinary guidance establishes obesity, high-fat, and preparation boundaries but does not name walnut. Feedipedia identifies walnut kernel as fat-rich. These sources do not establish a walnut outcome, so no cross-species inference is made. A documented second targeted search was completed; its queries and result are recorded in followUpSearch.",
+          "reviewedAt": "2026-08-19",
+          "followUpSearch": {
+            "queries": [
+              "budgie walnut raw unsalted veterinarian",
+              "Wellensittich Walnuss ungesalzen Fütterung"
+            ],
+            "sourceIds": [
+              "welli-net-walnuts-budgies-2025",
+              "vca-budgie-feeding"
+            ],
+            "result": "The species-specific German discussion contains conflicting non-clinical guidance: warnings about oil/fat, occasional-use comments, and a warning about invisible fungal spores in fresh walnuts. VCA does not name walnut, so the exact outcome remains unresolved."
+          }
         },
         {
           "bird": "canary",
@@ -1833,8 +1877,19 @@
           ],
           "locator": "VCA Canaries feeding sections on obesity, small quantities, and no butter/salt/cooking oil; Feedipedia kernel composition",
           "evidenceScope": "species_specific",
-          "rationale": "Canary-specific veterinary guidance establishes balanced-diet, high-fat, and no-oil/salt boundaries but does not name walnut. Feedipedia identifies walnut kernel as fat-rich. The exact walnut form therefore remains unresolved rather than being inferred from parrot guidance.",
-          "reviewedAt": "2026-08-19"
+          "rationale": "Canary-specific veterinary guidance establishes balanced-diet, high-fat, and no-oil/salt boundaries but does not name walnut. Feedipedia identifies walnut kernel as fat-rich. The exact walnut form therefore remains unresolved rather than being inferred from parrot guidance. A documented second targeted search was completed; its queries and result are recorded in followUpSearch.",
+          "reviewedAt": "2026-08-19",
+          "followUpSearch": {
+            "queries": [
+              "canary walnut raw unsalted veterinarian",
+              "Kanarienvogel Walnuss ungesalzen Fütterung"
+            ],
+            "sourceIds": [
+              "vogelforen-walnuts-canaries-2007",
+              "vca-canary-feeding"
+            ],
+            "result": "The species-specific German discussion repeatedly advises against walnuts because of high fat, but it is an owner forum and conflicts with the absence of a direct veterinary walnut rule. The exact outcome remains unresolved."
+          }
         },
         {
           "bird": "chicken",
@@ -1845,8 +1900,20 @@
           ],
           "locator": "Jiang et al. 2024 broiler walnut-meal experiment; Feedipedia poultry walnut-meal section",
           "evidenceScope": "species_specific",
-          "rationale": "Chicken evidence concerns walnut meal powder or historical walnut oil-meal/by-products in formulated poultry diets, not whole shelled kernel as a treat. Because the exact form differs, chicken whole-kernel suitability remains unresolved.",
-          "reviewedAt": "2026-08-19"
+          "rationale": "Chicken evidence concerns walnut meal powder or historical walnut oil-meal/by-products in formulated poultry diets, not whole shelled kernel as a treat. Because the exact form differs, chicken whole-kernel suitability remains unresolved. A documented second targeted search was completed; its queries and result are recorded in followUpSearch.",
+          "reviewedAt": "2026-08-19",
+          "followUpSearch": {
+            "queries": [
+              "chicken whole walnut kernel feeding study poultry",
+              "broiler walnut kernels raw unsalted diet study",
+              "Hühner Walnüsse Walnusskerne Fütterung"
+            ],
+            "sourceIds": [
+              "jiang-walnut-meal-broilers-2024",
+              "huehner-info-nuts-2023"
+            ],
+            "result": "Peer-reviewed results concern walnut meal/oilcake rather than whole kernels. German and English backyard sources discuss walnuts as occasional treats but do not establish a controlled exact-form outcome; whole-kernel suitability remains unresolved."
+          }
         }
       ],
       "processing": {

--- a/database/provenance/food-reviews.json
+++ b/database/provenance/food-reviews.json
@@ -1764,6 +1764,105 @@
         "severity": "warning"
       },
       "lastReviewedAt": "2026-08-19"
+    },
+    {
+      "ingredientId": "walnut",
+      "ingredientDisplayName": "Walnut",
+      "form": "plain shelled walnut kernel, raw or dry-roasted, unsalted, unflavoured, fresh, and chopped to small-seed size",
+      "nutrition": {
+        "sourceIds": [
+          "feedipedia-walnut-juglans-regia"
+        ],
+        "basis": "not_applicable",
+        "notes": "Evidence-only record for the specified kernel form. It does not add a nutrient value, a dry-mix ingredient instruction, or a complete-ration claim."
+      },
+      "speciesEvidence": [
+        {
+          "bird": "pigeon",
+          "outcome": "unresolved",
+          "sourceIds": [
+            "petco-pigeon-cashew-preparation-2019"
+          ],
+          "locator": "Veterinarian answer: pigeons cannot masticate and nut pieces should be chopped to small-seed size",
+          "evidenceScope": "species_specific",
+          "rationale": "The pigeon-specific source establishes a mechanical-size boundary for cashew pieces, not walnut suitability. No direct pigeon walnut source was found, so walnut remains unresolved rather than being inferred from parrot or poultry evidence.",
+          "reviewedAt": "2026-08-19"
+        },
+        {
+          "bird": "parrot",
+          "outcome": "limited",
+          "sourceIds": [
+            "lafeber-walnut-nutrition-2020",
+            "feedipedia-walnut-juglans-regia"
+          ],
+          "locator": "Lafeber walnut-nutrition answer; Feedipedia kernel composition and rancidity sections",
+          "evidenceScope": "group_specific",
+          "rationale": "Lafeber directly supports small walnut pieces as an occasional Amazon-parrot reward within a predominantly complete diet. Feedipedia supports treating walnut kernel as a high-fat, freshness-sensitive food. This supports limited companion-parrot use only and does not approve a dry-mix ingredient, universal portion, or roasted form.",
+          "reviewedAt": "2026-08-19"
+        },
+        {
+          "bird": "african_grey",
+          "outcome": "limited",
+          "sourceIds": [
+            "vca-african-grey-feeding",
+            "feedipedia-walnut-juglans-regia"
+          ],
+          "locator": "VCA African Grey 'Seeds' section naming walnuts among occasional tree nuts; Feedipedia kernel composition and freshness sections",
+          "evidenceScope": "species_specific",
+          "rationale": "VCA explicitly names walnuts among the couple of tree nuts that may be offered daily to an African Grey while pellets remain the diet base, and warns about obesity and high-fat diets. Feedipedia supports the high-fat and freshness boundary. This is limited treat guidance, not formula inclusion or an unrestricted raw/roasted approval.",
+          "reviewedAt": "2026-08-19"
+        },
+        {
+          "bird": "budgie",
+          "outcome": "unresolved",
+          "sourceIds": [
+            "vca-budgie-feeding",
+            "feedipedia-walnut-juglans-regia"
+          ],
+          "locator": "VCA Budgies feeding sections on obesity, high-fat foods, tiny human-food portions, and avoidance of butter/oil-cooked foods; Feedipedia kernel composition",
+          "evidenceScope": "species_specific",
+          "rationale": "Budgie-specific veterinary guidance establishes obesity, high-fat, and preparation boundaries but does not name walnut. Feedipedia identifies walnut kernel as fat-rich. These sources do not establish a walnut outcome, so no cross-species inference is made.",
+          "reviewedAt": "2026-08-19"
+        },
+        {
+          "bird": "canary",
+          "outcome": "unresolved",
+          "sourceIds": [
+            "vca-canary-feeding",
+            "feedipedia-walnut-juglans-regia"
+          ],
+          "locator": "VCA Canaries feeding sections on obesity, small quantities, and no butter/salt/cooking oil; Feedipedia kernel composition",
+          "evidenceScope": "species_specific",
+          "rationale": "Canary-specific veterinary guidance establishes balanced-diet, high-fat, and no-oil/salt boundaries but does not name walnut. Feedipedia identifies walnut kernel as fat-rich. The exact walnut form therefore remains unresolved rather than being inferred from parrot guidance.",
+          "reviewedAt": "2026-08-19"
+        },
+        {
+          "bird": "chicken",
+          "outcome": "unresolved",
+          "sourceIds": [
+            "jiang-walnut-meal-broilers-2024",
+            "feedipedia-walnut-juglans-regia"
+          ],
+          "locator": "Jiang et al. 2024 broiler walnut-meal experiment; Feedipedia poultry walnut-meal section",
+          "evidenceScope": "species_specific",
+          "rationale": "Chicken evidence concerns walnut meal powder or historical walnut oil-meal/by-products in formulated poultry diets, not whole shelled kernel as a treat. Because the exact form differs, chicken whole-kernel suitability remains unresolved.",
+          "reviewedAt": "2026-08-19"
+        }
+      ],
+      "processing": {
+        "sourceIds": [
+          "petco-pigeon-cashew-preparation-2019",
+          "lafeber-walnut-nutrition-2020",
+          "vca-african-grey-feeding",
+          "vca-budgie-feeding",
+          "vca-canary-feeding",
+          "feedipedia-walnut-juglans-regia",
+          "jiang-walnut-meal-broilers-2024"
+        ],
+        "rule": "Keep plain shelled walnut kernel distinct from walnut meal, oil meal, shell, husk, black walnut green material, moldy product, and rancid product. For the specified kernel form, use only fresh, unsalted, unflavoured product and chop to small-seed size where the bird-specific evidence requires a manageable piece. This provenance record does not approve soaking, a household roasting method, a portion, a formula, runtime use, or a complete ration.",
+        "severity": "warning"
+      },
+      "lastReviewedAt": "2026-08-19"
     }
   ]
 }

--- a/database/provenance/sources.json
+++ b/database/provenance/sources.json
@@ -958,6 +958,69 @@
       "permittedUse": "German parrot and parakeet guidance distinguishing processed edible kernels from the shell liquid and discussing cashew nutrition.",
       "limitations": "Owner education article; it does not establish a budgie-specific controlled outcome, exact roasted form, portion, or runtime formula use.",
       "accessedAt": "2026-08-19"
+    },
+    {
+      "id": "lafeber-walnut-nutrition-2020",
+      "title": "Walnut nutrition",
+      "authorsOrOrganization": "Brenda; Lafeber Company",
+      "publishedYear": "2020",
+      "sourceTier": "owner_guidance_with_citations",
+      "urlOrDoi": "https://lafeber.com/pet-birds/questions/walnut-nutrition/",
+      "speciesScopes": [
+        "parrot"
+      ],
+      "permittedUse": "Direct Amazon-parrot guidance for small walnut pieces as an occasional reward within a predominantly complete diet.",
+      "limitations": "Owner-facing guidance for an Amazon parrot; it does not establish a universal parrot portion, a dry-mix ingredient, or an outcome for pigeons, African Greys, budgies, canaries, chickens, or roasted walnut specifically.",
+      "accessedAt": "2026-08-19"
+    },
+    {
+      "id": "petco-pigeon-cashew-preparation-2019",
+      "title": "Is it safe to feed my pigeon cashew nuts? How should I prepare them?",
+      "authorsOrOrganization": "Todd Cecil, Veterinarian; Petco",
+      "publishedYear": "2019",
+      "sourceTier": "owner_guidance_with_citations",
+      "urlOrDoi": "https://www.petco.com/pet-education/bird/vet-qa/pigeon-safe-cashew-nuts-preparation",
+      "speciesScopes": [
+        "pigeon"
+      ],
+      "permittedUse": "Pigeon-specific mechanical-size guidance that nut pieces should be chopped to small-seed size because pigeons cannot masticate.",
+      "limitations": "The answer addresses cashews rather than walnuts and does not establish walnut safety, toxicity, portion, or dry-roasted use.",
+      "accessedAt": "2026-08-19"
+    },
+    {
+      "id": "feedipedia-walnut-juglans-regia",
+      "title": "Walnut (Juglans regia)",
+      "authorsOrOrganization": "Feedipedia; Association Française de Zootechnie, CIRAD, FAO, INRAE",
+      "publishedYear": "2012",
+      "sourceTier": "veterinary_reference",
+      "urlOrDoi": "https://www.feedipedia.org/node/38",
+      "speciesScopes": [
+        "chicken",
+        "poultry",
+        "parrot",
+        "african_grey",
+        "budgie",
+        "canary",
+        "pigeon"
+      ],
+      "permittedUse": "Ingredient-form distinction for walnut kernel, toasted kernel, oil meal, shell, and husk; high-fat and rancidity/mould boundaries; historical poultry by-product context.",
+      "limitations": "The datasheet is not a six-bird whole-kernel feeding trial and its poultry discussion concerns walnut meal/by-products rather than the exact companion-bird treat form.",
+      "accessedAt": "2026-08-19"
+    },
+    {
+      "id": "jiang-walnut-meal-broilers-2024",
+      "title": "Walnut meal improves meat quality by modulating intestinal microbes in white feather broilers",
+      "authorsOrOrganization": "Xingjiao Jiang et al.",
+      "publishedYear": "2024",
+      "sourceTier": "primary",
+      "urlOrDoi": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11336344/",
+      "speciesScopes": [
+        "chicken",
+        "broiler_chicken"
+      ],
+      "permittedUse": "Controlled broiler evidence for 5% and 10% walnut meal powder in formulated diets.",
+      "limitations": "Walnut meal powder is not whole walnut kernel; the study does not establish household feeding, a treat portion, raw or dry-roasted kernel use, or outcomes for other birds.",
+      "accessedAt": "2026-08-19"
     }
   ]
 }

--- a/database/provenance/sources.json
+++ b/database/provenance/sources.json
@@ -841,8 +841,8 @@
       "speciesScopes": [
         "parrot"
       ],
-      "permittedUse": "Parrot owner guidance listing cashews among treat nuts, with raw or dry-roasted, unsalted, unflavoured, small-portion, and high-fat moderation boundaries.",
-      "limitations": "Owner-answer guidance for parrots; it does not establish African Grey, budgie, canary, pigeon, or chicken outcomes and does not create a universal portion.",
+      "permittedUse": "Parrot owner guidance naming cashews and walnuts among small treat nuts; supports raw or dry-roasted, unsalted, unflavoured nuts in moderation and rejects oil-roasted nuts.",
+      "limitations": "Owner-answer guidance for parrot contexts; it does not establish a universal portion, a complete ration, African Grey-specific quantities, or outcomes for pigeons, budgies, canaries, chickens, walnut meal, or shell-on nuts.",
       "accessedAt": "2026-08-19"
     },
     {
@@ -1020,20 +1020,6 @@
       ],
       "permittedUse": "Controlled broiler evidence for 5% and 10% walnut meal powder in formulated diets.",
       "limitations": "Walnut meal powder is not whole walnut kernel; the study does not establish household feeding, a treat portion, raw or dry-roasted kernel use, or outcomes for other birds.",
-      "accessedAt": "2026-08-19"
-    },
-    {
-      "id": "lafeber-nut-meats-2026",
-      "title": "Nut Meats",
-      "authorsOrOrganization": "Lafeber Company",
-      "publishedYear": "2026",
-      "sourceTier": "owner_guidance_with_citations",
-      "urlOrDoi": "https://lafeber.com/pet-birds/questions/nut-meats/",
-      "speciesScopes": [
-        "parrot"
-      ],
-      "permittedUse": "Meyer-parrot guidance naming walnuts and distinguishing raw, dry-roasted unsalted, and oil-roasted nuts, with small-treat moderation.",
-      "limitations": "Owner-facing guidance for a Meyer’s parrot; it does not establish a universal parrot rule, an African Grey-specific portion, or outcomes for pigeons, budgies, canaries, chickens, or walnut meal.",
       "accessedAt": "2026-08-19"
     },
     {

--- a/database/provenance/sources.json
+++ b/database/provenance/sources.json
@@ -1021,6 +1021,62 @@
       "permittedUse": "Controlled broiler evidence for 5% and 10% walnut meal powder in formulated diets.",
       "limitations": "Walnut meal powder is not whole walnut kernel; the study does not establish household feeding, a treat portion, raw or dry-roasted kernel use, or outcomes for other birds.",
       "accessedAt": "2026-08-19"
+    },
+    {
+      "id": "lafeber-nut-meats-2026",
+      "title": "Nut Meats",
+      "authorsOrOrganization": "Lafeber Company",
+      "publishedYear": "2026",
+      "sourceTier": "owner_guidance_with_citations",
+      "urlOrDoi": "https://lafeber.com/pet-birds/questions/nut-meats/",
+      "speciesScopes": [
+        "parrot"
+      ],
+      "permittedUse": "Meyer-parrot guidance naming walnuts and distinguishing raw, dry-roasted unsalted, and oil-roasted nuts, with small-treat moderation.",
+      "limitations": "Owner-facing guidance for a Meyer’s parrot; it does not establish a universal parrot rule, an African Grey-specific portion, or outcomes for pigeons, budgies, canaries, chickens, or walnut meal.",
+      "accessedAt": "2026-08-19"
+    },
+    {
+      "id": "welli-net-walnuts-budgies-2025",
+      "title": "Walnüsse für Wellis, was gibt es da zu beachten?",
+      "authorsOrOrganization": "Welli.net community discussion",
+      "publishedYear": "2025",
+      "sourceTier": "owner_guidance_with_citations",
+      "urlOrDoi": "https://forum.welli.net/forum/alles-%C3%BCber-wellensittiche/ern%C3%A4hrung/293920-waln%C3%BCsse-f%C3%BCr-wellis-was-gibt-es-da-zu-beachten",
+      "speciesScopes": [
+        "budgie"
+      ],
+      "permittedUse": "Species-specific German owner discussion documenting conflicting budgie advice about walnut fat/oil, occasional use, and fresh-walnut fungal-spore concerns.",
+      "limitations": "Conflicting non-clinical forum discussion; it cannot establish a veterinary approval, prohibition, portion, roasting method, or runtime outcome.",
+      "accessedAt": "2026-08-19"
+    },
+    {
+      "id": "vogelforen-walnuts-canaries-2007",
+      "title": "Walnüsse für kanarien?",
+      "authorsOrOrganization": "Vogelforen community discussion",
+      "publishedYear": "2007",
+      "sourceTier": "owner_guidance_with_citations",
+      "urlOrDoi": "https://www.vogelforen.de/threads/walnuesse-fuer-kanarien.153005/",
+      "speciesScopes": [
+        "canary"
+      ],
+      "permittedUse": "Species-specific German owner discussion documenting repeated caution against walnuts for canaries because of high fat.",
+      "limitations": "Owner forum with conflicting opinions; it cannot establish a veterinary approval, prohibition, portion, roasting method, or runtime outcome.",
+      "accessedAt": "2026-08-19"
+    },
+    {
+      "id": "huehner-info-nuts-2023",
+      "title": "Futter: Nüsse",
+      "authorsOrOrganization": "Hühner-Info community resource",
+      "publishedYear": "2023",
+      "sourceTier": "owner_guidance_with_citations",
+      "urlOrDoi": "https://huehner-info.de/infos/futter_nuesse.htm",
+      "speciesScopes": [
+        "chicken"
+      ],
+      "permittedUse": "German chicken-keeping discussion describing nuts as high-fat and potentially suitable only as small treats.",
+      "limitations": "Non-clinical community guidance; it does not establish a controlled whole-walnut feeding outcome or a complete-ration role.",
+      "accessedAt": "2026-08-19"
     }
   ]
 }

--- a/v3-webapp/client/src/lib/provenance-ledger.test.ts
+++ b/v3-webapp/client/src/lib/provenance-ledger.test.ts
@@ -242,6 +242,22 @@ describe("canonical provenance ledger", () => {
     ]);
     expect(review?.speciesEvidence.every((entry) => entry.sourceIds.length > 0)).toBe(true);
   });
+  it("records a documented second targeted search for every walnut bird/form pair", () => {
+    const ledger = readJson("food-reviews.json") as {
+      ingredientReviews: Array<{
+        ingredientId: string;
+        form: string;
+        speciesEvidence: Array<{ bird: string; followUpSearch: { queries: string[]; sourceIds: string[]; result: string } }>;
+      }>;
+    };
+    const review = ledger.ingredientReviews.find(
+      (candidate) => candidate.ingredientId === "walnut" && candidate.form === "plain shelled walnut kernel, raw or dry-roasted, unsalted, unflavoured, fresh, and chopped to small-seed size",
+    );
+    expect(review?.speciesEvidence).toHaveLength(6);
+    expect(review?.speciesEvidence.every((entry) => entry.followUpSearch.queries.length >= 2)).toBe(true);
+    expect(review?.speciesEvidence.every((entry) => entry.followUpSearch.sourceIds.length > 0)).toBe(true);
+    expect(review?.speciesEvidence.every((entry) => entry.followUpSearch.result.length > 0)).toBe(true);
+  });
   it("records the approved insect forms with six birds and exact outcomes", () => {
     const ledger = readJson("food-reviews.json") as {
       requiredBirdOrder: string[];

--- a/v3-webapp/client/src/lib/provenance-ledger.test.ts
+++ b/v3-webapp/client/src/lib/provenance-ledger.test.ts
@@ -219,6 +219,29 @@ describe("canonical provenance ledger", () => {
     }
   });
 
+  it("records the walnut form with six birds and evidence-only outcomes", () => {
+    const ledger = readJson("food-reviews.json") as {
+      requiredBirdOrder: string[];
+      ingredientReviews: Array<{
+        ingredientId: string;
+        form: string;
+        speciesEvidence: Array<{ bird: string; outcome: string; sourceIds: string[] }>;
+      }>;
+    };
+    const review = ledger.ingredientReviews.find(
+      (candidate) => candidate.ingredientId === "walnut" && candidate.form === "plain shelled walnut kernel, raw or dry-roasted, unsalted, unflavoured, fresh, and chopped to small-seed size",
+    );
+    expect(review?.speciesEvidence.map((entry) => entry.bird)).toEqual(ledger.requiredBirdOrder);
+    expect(review?.speciesEvidence.map((entry) => entry.outcome)).toEqual([
+      "unresolved",
+      "limited",
+      "limited",
+      "unresolved",
+      "unresolved",
+      "unresolved",
+    ]);
+    expect(review?.speciesEvidence.every((entry) => entry.sourceIds.length > 0)).toBe(true);
+  });
   it("records the approved insect forms with six birds and exact outcomes", () => {
     const ledger = readJson("food-reviews.json") as {
       requiredBirdOrder: string[];


### PR DESCRIPTION
## Summary

Closes #131 and contributes to #70.

This PR adds a provenance-only six-bird evidence ledger for the exact form **plain shelled walnut kernel, raw or dry-roasted, unsalted, unflavoured, fresh, and chopped to small-seed size**.

The first version of this PR summarized the six outcomes but did not preserve the complete second-pass search trail. Commit `0434149d` corrects that omission by adding the follow-up search queries, source links, and results to every walnut species row, plus regression coverage requiring all six rows to carry a documented follow-up search.

## Research coverage

The six independent first-pass searches were followed by targeted second-pass searches wherever the first pass did not establish the exact bird/form outcome:

| Bird | Recorded outcome | Evidence and follow-up result |
|---|---|---|
| Pigeon | `unresolved` | VCA pigeon/dove guidance confirms tiny manageable pieces but does not name walnut. Community and German results were not authoritative direct walnut evidence. |
| Parrot | `limited` | Lafeber directly names walnuts for Meyer parrots, prefers raw, accepts dry-roasted unsalted in moderation, rejects oil-roasted nuts, and limits nuts to a small dietary share. |
| African Grey | `limited` | VCA directly names walnuts among occasional tree nuts. The second search found no stronger exact-form clinical rule, so this remains limited rather than unrestricted. |
| Budgie | `unresolved` | Welli.net’s German species-specific discussion contains conflicting non-clinical advice about fat, occasional use, and fresh-walnut fungal-spore concerns; VCA does not name walnut. |
| Canary | `unresolved` | Vogelforen’s German species-specific discussion repeatedly cautions against walnuts because of high fat, but it is an owner forum and does not establish a clinical rule. |
| Chicken | `unresolved` | Peer-reviewed evidence concerns walnut meal/oilcake, not whole kernels. German and English backyard sources discuss treats but do not establish a controlled exact-form outcome. |

The follow-up search queries and result statements are stored directly in each walnut species row under `followUpSearch`; the research notes also preserve the broader search log.

## Scope

- Registered four additional follow-up sources in `database/provenance/sources.json`.
- Added per-species second-pass search records to the walnut review in `database/provenance/food-reviews.json`.
- Added a regression assertion requiring six documented follow-up searches.
- Preserved distinctions between whole kernel, walnut meal/oil meal, shell/husk, moldy product, and rancid product.

## Validation

- `node database/tools/validate-provenance-ledger.mjs` — passed; 55 sources and 15 food reviews.
- `cd v3-webapp && pnpm exec vitest run client/src/lib/provenance-ledger.test.ts` — 12/12 tests passed.
- `cd v3-webapp && pnpm check` — passed.
- `git diff --check` — passed.

## What did not change

No active ingredient data, runtime formulas, calculator behavior, website behavior, public-facing copy, safety outcomes, Firestore queue/region configuration, or deployment configuration changed. This PR does not infer cross-species suitability and does not make walnut a runtime ingredient.

## Owner decision requested

Please review the complete source-to-statement links and the documented first/second-pass searches, especially the unresolved pigeon, budgie, canary, and chicken rows. Approve this PR in Manus chat if the evidence ledger should be retained as written. I will not merge it without your explicit approval.
