### PR TITLE
fix: choose a safe diversity candidate only for actual inventory (#83)

### DIFF
--- a/v3-webapp/client/src/lib/diversity-suggestion.test.ts
+++ b/v3-webapp/client/src/lib/diversity-suggestion.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { checkBirdToxicity, isIngredientCompatible } from "@/lib/bird-safety";
+import { selectDiversitySuggestionCandidate } from "@/lib/diversity-suggestion";
+import { getProcessingWarning, isToxicRaw } from "@/lib/safety";
+
+describe("selectDiversitySuggestionCandidate", () => {
+  const mix = { corn_yellow: 600, peas: 250, safflower: 150 };
+
+  it("suppresses the banner candidate while the profile-default formula is displayed", () => {
+    expect(
+      selectDiversitySuggestionCandidate({
+        bird: "pigeon",
+        formulaSource: "profile-default",
+        mix,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns a stable safe candidate that is absent from an actual inventory calculation", () => {
+    const first = selectDiversitySuggestionCandidate({ bird: "pigeon", formulaSource: "inventory", mix });
+    const second = selectDiversitySuggestionCandidate({ bird: "pigeon", formulaSource: "inventory", mix });
+
+    expect(first).toBe(second);
+    expect(first).not.toBeNull();
+    expect(mix[first as keyof typeof mix]).toBeUndefined();
+    expect(isIngredientCompatible(first as string, "pigeon")).toBe(true);
+    expect(isToxicRaw(first as string)).toBeFalsy();
+    expect(checkBirdToxicity(first as string, "pigeon")).toBeNull();
+    expect(getProcessingWarning(first as string)).toBeFalsy();
+  });
+
+  it("suppresses the candidate when the completed mix reports missing ingredients", () => {
+    expect(
+      selectDiversitySuggestionCandidate({
+        bird: "pigeon",
+        formulaSource: "inventory",
+        mix,
+        missingIngredients: ["safe grain"],
+      }),
+    ).toBeNull();
+  });
+});

--- a/v3-webapp/client/src/lib/diversity-suggestion.ts
+++ b/v3-webapp/client/src/lib/diversity-suggestion.ts
@@ -1,0 +1,51 @@
+import { checkBirdToxicity, isIngredientCompatible } from "@/lib/bird-safety";
+import type { BirdType } from "@/lib/birds";
+import type { MixResult } from "@/lib/calculator-multi-bird";
+import { INGREDIENTS } from "@/lib/data";
+import type { FormulaSource } from "@/lib/formula-display";
+import { getProcessingWarning, isToxicRaw } from "@/lib/safety";
+
+export function selectDiversitySuggestionCandidate({
+  bird,
+  formulaSource,
+  mix,
+  missingIngredients,
+}: {
+  bird: BirdType;
+  formulaSource: FormulaSource;
+  mix: Record<string, number>;
+  missingIngredients?: MixResult["missingIngredients"];
+}): string | null {
+  if (formulaSource !== "inventory" || missingIngredients?.length || !Object.keys(mix).length) return null;
+
+  const candidates = Object.keys(INGREDIENTS)
+    .filter((name) => !mix[name])
+    .filter(
+      (name) =>
+        isIngredientCompatible(name, bird) &&
+        !isToxicRaw(name) &&
+        !checkBirdToxicity(name, bird) &&
+        !getProcessingWarning(name),
+    )
+    .sort();
+
+  if (!candidates.length) return null;
+
+  const mixFingerprint = Object.entries(mix)
+    .filter(([, amount]) => amount > 0)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, amount]) => `${name}:${amount}`)
+    .join("|");
+  const candidateIndex = stableHash(`${bird}|${mixFingerprint}`) % candidates.length;
+
+  return candidates[candidateIndex];
+}
+
+function stableHash(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}

--- a/v3-webapp/client/src/pages/Home.tsx
+++ b/v3-webapp/client/src/pages/Home.tsx
@@ -47,6 +47,7 @@ import { MultibirMixCalculator, type MixResult } from "@/lib/calculator-multi-bi
 import { getPreparationInstructions, getProcessingWarning, isToxicRaw } from "@/lib/safety";
 import { getProfileDefaultIngredients } from "@/lib/inventory-presets";
 import { resolveDisplayedFormula } from "@/lib/formula-display";
+import { selectDiversitySuggestionCandidate } from "@/lib/diversity-suggestion";
 import { cn } from "@/lib/utils";
 import { Link } from "wouter";
 
@@ -95,15 +96,15 @@ export default function Home() {
   );
 
   const diversitySuggestion = useMemo(() => {
-    if (result.missingIngredients?.length || !Object.keys(result.mix).length) return null;
-
-    const candidate = ["barley", "oats", "millet", "sorghum", "buckwheat", "wheat", "rice_brown"]
-      .filter((name) => !result.mix[name])
-      .filter((name) => isIngredientCompatible(name, selectedBird) && !isToxicRaw(name) && !checkBirdToxicity(name, selectedBird) && !getProcessingWarning(name))
-      .find((name) => INGREDIENTS[name]?.category === "grain");
+    const candidate = selectDiversitySuggestionCandidate({
+      bird: selectedBird,
+      formulaSource,
+      mix: result.mix,
+      missingIngredients: result.missingIngredients,
+    });
 
     return candidate ? `Try offering ${candidate.replace(/_/g, " ")} alongside this mix to increase diversity for your bird.` : null;
-  }, [result, selectedBird]);
+  }, [formulaSource, result, selectedBird]);
 
   const ingredientOptions = useMemo(() => {
     const query = ingredientSearch.trim().toLowerCase();


### PR DESCRIPTION
## Scope

Closes #83. Replaces the fixed barley-first diversity candidate with a stable hash-selected, safe active-catalog ingredient absent from the calculated mix. The selection is deterministic for the same bird and completed mix, so it does not flicker on re-render; it changes only when the mix/bird changes.

The banner is now suppressed when the displayed formula is the selected profile’s standard reference, when the calculation has missing ingredients, or when no safe absent candidate remains.

## Validation

- Added `diversity-suggestion.test.ts`: profile-default suppression; deterministic selection; candidate absence from the mix; bird compatibility; raw-toxicity, species-toxicity, and processing boundaries; missing-ingredient suppression.
- Passed focused Vitest, provenance ledger validation (15 tests), calculator scenarios (21), care-guidance validation, TypeScript, production build, and `git diff --check`.

## What did not change

No solver policy, formula, nutrition target, active ingredient data, safety rule, provenance record, Firebase/Firestore configuration, or deployment routing changed.

### Public-facing copy

No visitor-visible strings changed. The existing sentence remains exactly: `Try offering {ingredient} alongside this mix to increase diversity for your bird.` Only the candidate-selection and display conditions changed.

## Requested owner decision

Please review this branch in the Manus preview. If the behavior is approved, explicitly authorize the merge in Manus chat; it will not be merged before that approval.