### PR TITLE
docs: model split lentils as an inherited form attribute

### DIFF
--- a/database/provenance/food-reviews.json
+++ b/database/provenance/food-reviews.json
@@ -858,6 +858,30 @@
       "ingredientId": "lentils",
       "ingredientDisplayName": "Lentils",
       "form": "raw dried lentil seeds",
+      "formAttributes": {
+        "model": "inherited_mechanical_form",
+        "attribute": "split",
+        "supportedValues": [
+          "whole",
+          "split"
+        ],
+        "defaultValue": "whole",
+        "inherits": [
+          "nutrition",
+          "speciesEvidence"
+        ],
+        "appliesTo": "Any lentil cultivar or colour within this raw dried base form; this physical-form attribute does not itself establish cultivar-specific nutrition or evidence.",
+        "inheritanceRule": "Mechanical splitting alone does not create a separate ingredient, nutrition record, or six-bird suitability record. A split raw dried lentil inherits this base record's nutrition and species evidence.",
+        "materialProcessingBoundaries": [
+          "dehulled",
+          "soaked",
+          "cooked",
+          "sprouted",
+          "fermented",
+          "milled into flour",
+          "manufactured lentil products"
+        ]
+      },
       "nutrition": {
         "sourceIds": [
           "ciurescu-2017-raw-lentil-broilers"
@@ -941,7 +965,7 @@
           "vca-canary-feeding",
           "ciurescu-2017-raw-lentil-broilers"
         ],
-        "rule": "Keep raw dried lentil seeds distinct from cooked lentils, sprouted lentils, lentil flour, and lentil products. Companion-bird records require preparation; chicken evidence is limited to the cited balanced broiler-ration context; pigeon evidence is limited uncited owner guidance. This record does not approve runtime use, a formula, a portion, or a complete ration.",
+        "rule": "A mechanically split raw dried lentil inherits this raw dried base record. Keep materially processed lentils—dehulled, soaked, cooked, sprouted, fermented, milled into flour, or manufactured products—distinct. Companion-bird records require preparation; chicken evidence is limited to the cited balanced broiler-ration context; pigeon evidence is limited uncited owner guidance. This record does not approve runtime use, a formula, a portion, or a complete ration.",
         "severity": "warning"
       },
       "lastReviewedAt": "2026-08-18"

--- a/database/tools/validate-provenance-ledger.mjs
+++ b/database/tools/validate-provenance-ledger.mjs
@@ -125,11 +125,48 @@ function validateHistoricalClaims(claims, sourceIndex, errors) {
   }
 }
 
+function validateFormAttributes(review, errors) {
+  if (review.formAttributes === undefined) {
+    return;
+  }
+
+  const attributes = review.formAttributes;
+  const context = `Food review '${review.ingredientId ?? "<missing ingredient id>"}' form attributes`;
+  if (!attributes || typeof attributes !== "object" || Array.isArray(attributes)) {
+    errors.push(`${context} must be an object when present.`);
+    return;
+  }
+
+  if (attributes.model !== "inherited_mechanical_form" || !isNonEmptyString(attributes.attribute)) {
+    errors.push(`${context} must declare the inherited_mechanical_form model and a named attribute.`);
+  }
+
+  if (!Array.isArray(attributes.supportedValues) || attributes.supportedValues.length < 2 || attributes.supportedValues.some((value) => !isNonEmptyString(value))) {
+    errors.push(`${context} must declare at least two non-empty supported values.`);
+  } else if (!attributes.supportedValues.includes(attributes.defaultValue)) {
+    errors.push(`${context} defaultValue must be one of its supported values.`);
+  }
+
+  if (!Array.isArray(attributes.inherits) || !["nutrition", "speciesEvidence"].every((field) => attributes.inherits.includes(field))) {
+    errors.push(`${context} must explicitly inherit both nutrition and speciesEvidence.`);
+  }
+
+  if (!isNonEmptyString(attributes.appliesTo) || !isNonEmptyString(attributes.inheritanceRule)) {
+    errors.push(`${context} must state its scope and inheritance rule.`);
+  }
+
+  if (!Array.isArray(attributes.materialProcessingBoundaries) || attributes.materialProcessingBoundaries.length === 0 || attributes.materialProcessingBoundaries.some((value) => !isNonEmptyString(value))) {
+    errors.push(`${context} must list one or more material-processing evidence boundaries.`);
+  }
+}
+
 function validateFoodReviews(reviews, sourceIndex, errors) {
   for (const review of reviews) {
     if (!isNonEmptyString(review.ingredientId) || !isNonEmptyString(review.form)) {
       errors.push("Every food review must have an ingredient ID and one explicit form.");
     }
+
+    validateFormAttributes(review, errors);
 
     const evidence = review.speciesEvidence;
     if (!Array.isArray(evidence) || evidence.length !== requiredBirds.length) {

--- a/v3-webapp/client/src/lib/provenance-ledger.test.ts
+++ b/v3-webapp/client/src/lib/provenance-ledger.test.ts
@@ -107,12 +107,20 @@ describe("canonical provenance ledger", () => {
     expect(rawChickpeaCoverage?.linkedFoodReviewKeys).toEqual(["chickpeas::raw dried seeds"]);
   });
 
-  it("records the five-item raw-legume batch with complete six-bird evidence and coverage links", () => {
+  it("records the five-item raw-legume batch with complete six-bird evidence, coverage links, and lentil split-form inheritance", () => {
     const foodLedger = readJson("food-reviews.json") as {
       requiredBirdOrder: string[];
       ingredientReviews: Array<{
         ingredientId: string;
         form: string;
+        formAttributes?: {
+          model: string;
+          attribute: string;
+          supportedValues: string[];
+          defaultValue: string;
+          inherits: string[];
+          materialProcessingBoundaries: string[];
+        };
         speciesEvidence: Array<{ bird: string; outcome: string; sourceIds: string[] }>;
       }>;
     };
@@ -174,6 +182,20 @@ describe("canonical provenance ledger", () => {
         `${expectedReview.ingredientId}::${expectedReview.form}`,
       ]);
     }
+
+    const lentilReview = foodLedger.ingredientReviews.find(
+      (candidate) => candidate.ingredientId === "lentils" && candidate.form === "raw dried lentil seeds",
+    );
+    expect(lentilReview?.formAttributes).toMatchObject({
+      model: "inherited_mechanical_form",
+      attribute: "split",
+      supportedValues: ["whole", "split"],
+      defaultValue: "whole",
+      inherits: ["nutrition", "speciesEvidence"],
+    });
+    expect(lentilReview?.formAttributes?.materialProcessingBoundaries).toEqual(
+      expect.arrayContaining(["dehulled", "soaked", "cooked", "sprouted", "fermented"]),
+    );
   });
 
   it("records each new food/form review with six birds and expected outcomes", () => {

--- a/v3-webapp/todo.md
+++ b/v3-webapp/todo.md
@@ -118,3 +118,4 @@
 - [x] Run focused and full V3 regression coverage without changing visitor-facing copy for Issue #107.
 - [x] Add a tested silent request limit after CodeQL identified the static fallback as an unbounded filesystem-access route on Issue #107.
 - [x] Upgrade the merged Firebase Admin production path and verify the reconciled report processor dependency graph has no known advisories.
+- [x] Implement and validate the Issue #134 attribute-aware lentil provenance model: purely split forms inherit base lentil nutrition and suitability; only material processing states create separate evidence boundaries; no runtime/catalog change.


### PR DESCRIPTION
Closes #134

## Scope
This provenance-only change gives the existing raw dried lentil record an explicit `split` mechanical form attribute. Whole and split raw dried lentils share the existing lentil nutrition reference and six-bird evidence. Materially processed forms—dehulled, soaked, cooked, sprouted, fermented, milled flour, and manufactured products—remain separate evidence boundaries.

## Validation
- `pnpm test:provenance` — validator plus 15 Vitest ledger tests passed
- `pnpm test:calculator` — 21 scenarios passed
- `pnpm --dir v3-webapp test:care-guidance` — passed
- `pnpm check` — passed
- `pnpm --dir v3-webapp build` — passed
- `git diff --check` — passed

## What did not change
- No active catalog ingredient, nutrient value, formula, safety rule, runtime adapter, or calculator behavior changed.
- No new food suitability outcome or source claim was added.
- No public-facing copy changed.

## Requested owner decision
Please review the model boundary and approve merging if it correctly reflects that mechanical splitting alone is inherited, while material processing remains a separate review boundary.