### PR TITLE
feat(optimizer): add pure constrained model builder

### DIFF
--- a/v3-webapp/client/src/lib/optimizer-model.test.ts
+++ b/v3-webapp/client/src/lib/optimizer-model.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { createRequire } from "node:module";
+
+import { BIRD_PROFILES, getCategoryTargets } from "./birds";
+import { INGREDIENTS } from "./data";
+import { getProfileDefaultIngredients } from "./inventory-presets";
+import { buildExactFeasibilityModel, type OptimizerCandidate } from "./optimizer-model";
+import { OPTIMIZER_POLICY } from "./optimizer-policy";
+
+const require = createRequire(import.meta.url);
+const createHighs = require("highs") as () => Promise<{ solve: (model: string) => { Status: string; Columns: Record<string, { Primal: number }> } }>;
+
+function activeCandidate(id: string, availableGrams: number): OptimizerCandidate {
+  const ingredient = INGREDIENTS[id];
+  if (!ingredient) throw new Error(`missing test ingredient ${id}`);
+  return {
+    id,
+    category: ingredient.category,
+    availableGrams,
+    nutrition: {
+      protein: ingredient.protein,
+      carbs: ingredient.carbs,
+      fat: ingredient.fat,
+      fiber: ingredient.fiber,
+    },
+    safetyState: "eligible",
+  };
+}
+
+describe("pure constrained optimizer model", () => {
+  const bird = "chicken";
+  const profile = BIRD_PROFILES[bird].profiles.pet;
+  const inventory = getProfileDefaultIngredients(bird, "pet");
+  const candidates = Object.entries(inventory).map(([id, grams]) => activeCandidate(id, grams));
+
+  it("uses the owner-approved, named, one-gram proof-of-concept policy", () => {
+    expect(OPTIMIZER_POLICY).toMatchObject({
+      gramIncrement: 1,
+      meaningfulInclusionGrams: 5,
+      exactMarginTolerance: 0,
+      maximumShareToleranceGrams: 0,
+      canonicalCandidateOrder: "ingredient_id_ascending",
+    });
+  });
+
+  it("builds byte-identical LP text from reordered active candidates", () => {
+    const direct = buildExactFeasibilityModel({
+      candidates,
+      requestedTargetGrams: 1000,
+      macroRanges: profile.nutrition,
+      categoryRanges: getCategoryTargets(bird),
+    });
+    const reordered = buildExactFeasibilityModel({
+      candidates: [...candidates].reverse(),
+      requestedTargetGrams: 1000,
+      macroRanges: profile.nutrition,
+      categoryRanges: getCategoryTargets(bird),
+    });
+
+    expect(direct.lp).toBe(reordered.lp);
+    expect(direct.candidates.map(({ id }) => id)).toEqual(["barley", "corn_yellow", "oats", "peas", "wheat"]);
+    expect(direct.achievableTargetGrams).toBe(1000);
+    expect(direct.lp).toContain("exact_weight:");
+    expect(direct.lp).toContain("protein_minimum:");
+    expect(direct.lp).toContain("seed_minimum:");
+    expect(direct.lp).toContain("maximum_share_wheat:");
+    expect(direct.lp).toContain("meaningful_lower_wheat:");
+  });
+
+  it("produces a real active-data LP that the pinned HiGHS development solver accepts", async () => {
+    const model = buildExactFeasibilityModel({
+      candidates,
+      requestedTargetGrams: 1000,
+      macroRanges: profile.nutrition,
+      categoryRanges: getCategoryTargets(bird),
+    });
+    const highs = await createHighs();
+    const solution = highs.solve(model.lp);
+    expect(solution.Status).toBe("Optimal");
+
+    const quantities = model.candidates.map(({ quantityVariable }) => solution.Columns[quantityVariable]?.Primal ?? Number.NaN);
+    expect(quantities.every(Number.isInteger)).toBe(true);
+    expect(quantities.reduce((sum, quantity) => sum + quantity, 0)).toBe(1000);
+    model.candidates.forEach((candidate, index) => {
+      expect(quantities[index]).toBeLessThanOrEqual(candidate.availableGrams);
+    });
+  });
+
+  it("caps the model at the safely available whole-gram inventory total", () => {
+    const model = buildExactFeasibilityModel({
+      candidates: [activeCandidate("wheat", 400.9), activeCandidate("peas", 299.8)],
+      requestedTargetGrams: 1000,
+      macroRanges: profile.nutrition,
+      categoryRanges: getCategoryTargets(bird),
+    });
+
+    expect(model.achievableTargetGrams).toBe(699);
+    expect(model.lp).toContain("exact_weight: 1 x_peas + 1 x_wheat = 699");
+    expect(model.lp).toContain("0 <= x_wheat <= 400");
+  });
+
+  it("rejects non-canonical identifiers, fractional target requests, excluded candidates, and invalid ranges", () => {
+    expect(() => buildExactFeasibilityModel({
+      candidates: [{ ...activeCandidate("wheat", 1000), id: "wheat-id" }],
+      requestedTargetGrams: 1000,
+      macroRanges: profile.nutrition,
+      categoryRanges: getCategoryTargets(bird),
+    })).toThrow("safe canonical identifier");
+    expect(() => buildExactFeasibilityModel({
+      candidates: [activeCandidate("wheat", 1000)],
+      requestedTargetGrams: 1000.5,
+      macroRanges: profile.nutrition,
+      categoryRanges: getCategoryTargets(bird),
+    })).toThrow("align to the configured gram increment");
+    expect(() => buildExactFeasibilityModel({
+      candidates: [{ ...activeCandidate("kidney_beans", 1000), safetyState: "excluded" }],
+      requestedTargetGrams: 1000,
+      macroRanges: profile.nutrition,
+      categoryRanges: getCategoryTargets(bird),
+    })).toThrow("did not pass the safety gate");
+    expect(() => buildExactFeasibilityModel({
+      candidates: [activeCandidate("wheat", 1000)],
+      requestedTargetGrams: 1000,
+      macroRanges: { ...profile.nutrition, protein: [15, 10] },
+      categoryRanges: getCategoryTargets(bird),
+    })).toThrow("protein range");
+  });
+});

--- a/v3-webapp/client/src/lib/optimizer-model.ts
+++ b/v3-webapp/client/src/lib/optimizer-model.ts
@@ -1,0 +1,164 @@
+import { OPTIMIZER_POLICY, type OptimizerPolicy } from "./optimizer-policy";
+
+export type OptimizerCategory = "grain" | "legume" | "seed";
+export type OptimizerMacro = "protein" | "carbs" | "fat" | "fiber";
+
+export type OptimizerRange = readonly [minimum: number, maximum: number];
+
+export interface OptimizerCandidate {
+  id: string;
+  category: OptimizerCategory;
+  availableGrams: number;
+  nutrition: Record<OptimizerMacro, number>;
+  safetyState: "eligible" | "excluded";
+}
+
+export interface OptimizerModelRequest {
+  candidates: readonly OptimizerCandidate[];
+  requestedTargetGrams: number;
+  macroRanges: Record<OptimizerMacro, OptimizerRange>;
+  categoryRanges: Record<OptimizerCategory, OptimizerRange>;
+  policy?: OptimizerPolicy;
+}
+
+export interface NormalizedOptimizerCandidate extends Omit<OptimizerCandidate, "availableGrams"> {
+  availableGrams: number;
+  quantityVariable: string;
+  meaningfulInclusionVariable?: string;
+}
+
+export interface OptimizerModel {
+  lp: string;
+  candidates: readonly NormalizedOptimizerCandidate[];
+  achievableTargetGrams: number;
+  policy: OptimizerPolicy;
+}
+
+const macroKeys: readonly OptimizerMacro[] = ["protein", "carbs", "fat", "fiber"];
+const categoryKeys: readonly OptimizerCategory[] = ["grain", "legume", "seed"];
+const identifierPattern = /^[a-z][a-z0-9_]*$/;
+const numericTolerance = 1e-9;
+
+function formatNumber(value: number): string {
+  const normalized = Math.abs(value) < numericTolerance ? 0 : value;
+  if (!Number.isFinite(normalized)) throw new Error(`Cannot format non-finite model value: ${value}`);
+  return Number.isInteger(normalized)
+    ? String(normalized)
+    : normalized.toFixed(9).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function formatExpression(terms: ReadonlyArray<{ coefficient: number; variable: string }>): string {
+  const nonZeroTerms = terms.filter(({ coefficient }) => Math.abs(coefficient) >= numericTolerance);
+  if (nonZeroTerms.length === 0) return "0";
+
+  return nonZeroTerms.map(({ coefficient, variable }, index) => {
+    const absolute = formatNumber(Math.abs(coefficient));
+    const prefix = index === 0 ? (coefficient < 0 ? "- " : "") : (coefficient < 0 ? " - " : " + ");
+    return `${prefix}${absolute} ${variable}`;
+  }).join("");
+}
+
+function assertRange(range: OptimizerRange, name: string): void {
+  const [minimum, maximum] = range;
+  if (!Number.isFinite(minimum) || !Number.isFinite(maximum) || minimum > maximum) {
+    throw new Error(`${name} must be a finite ascending range`);
+  }
+}
+
+function assertPolicy(policy: OptimizerPolicy): void {
+  if (!Number.isInteger(policy.gramIncrement) || policy.gramIncrement <= 0) {
+    throw new Error("optimizer gram increment must be a positive whole number");
+  }
+  if (!Number.isInteger(policy.meaningfulInclusionGrams) || policy.meaningfulInclusionGrams < policy.gramIncrement) {
+    throw new Error("meaningful inclusion must be a whole number at least as large as the gram increment");
+  }
+}
+
+function normalizeCandidates(candidates: readonly OptimizerCandidate[], policy: OptimizerPolicy): readonly NormalizedOptimizerCandidate[] {
+  const ids = new Set<string>();
+  return [...candidates]
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map((candidate) => {
+      if (!identifierPattern.test(candidate.id)) throw new Error(`candidate id '${candidate.id}' is not a safe canonical identifier`);
+      if (ids.has(candidate.id)) throw new Error(`candidate id '${candidate.id}' is duplicated`);
+      ids.add(candidate.id);
+      if (candidate.safetyState !== "eligible") throw new Error(`candidate '${candidate.id}' did not pass the safety gate`);
+      if (!Number.isFinite(candidate.availableGrams) || candidate.availableGrams < 0) {
+        throw new Error(`candidate '${candidate.id}' has invalid available grams`);
+      }
+
+      for (const macro of macroKeys) {
+        if (!Number.isFinite(candidate.nutrition[macro])) throw new Error(`candidate '${candidate.id}' has invalid ${macro} nutrition`);
+      }
+
+      const availableGrams = Math.floor(candidate.availableGrams / policy.gramIncrement) * policy.gramIncrement;
+      const quantityVariable = `x_${candidate.id}`;
+      return {
+        ...candidate,
+        availableGrams,
+        quantityVariable,
+        ...(availableGrams >= policy.meaningfulInclusionGrams ? { meaningfulInclusionVariable: `z_${candidate.id}` } : {}),
+      };
+    });
+}
+
+export function buildExactFeasibilityModel(request: OptimizerModelRequest): OptimizerModel {
+  const policy = request.policy ?? OPTIMIZER_POLICY;
+  assertPolicy(policy);
+  if (!Number.isFinite(request.requestedTargetGrams) || request.requestedTargetGrams < 0) {
+    throw new Error("requested target grams must be finite and non-negative");
+  }
+  if (request.requestedTargetGrams % policy.gramIncrement !== 0) {
+    throw new Error("requested target grams must align to the configured gram increment");
+  }
+
+  for (const macro of macroKeys) assertRange(request.macroRanges[macro], `${macro} range`);
+  for (const category of categoryKeys) assertRange(request.categoryRanges[category], `${category} range`);
+
+  const candidates = normalizeCandidates(request.candidates, policy);
+  const availableTotal = candidates.reduce((total, candidate) => total + candidate.availableGrams, 0);
+  const achievableTargetGrams = Math.min(request.requestedTargetGrams, availableTotal);
+
+  if (achievableTargetGrams === 0) throw new Error("no positive, safe eligible inventory is available for the model");
+
+  const lines = ["Minimize", " exact_feasibility: 0", "Subject To"];
+  lines.push(` exact_weight: ${formatExpression(candidates.map(({ quantityVariable }) => ({ coefficient: 1, variable: quantityVariable })))} = ${formatNumber(achievableTargetGrams)}`);
+
+  for (const macro of macroKeys) {
+    const [minimum, maximum] = request.macroRanges[macro];
+    const expression = formatExpression(candidates.map(({ nutrition, quantityVariable }) => ({ coefficient: nutrition[macro], variable: quantityVariable })));
+    lines.push(` ${macro}_minimum: ${expression} >= ${formatNumber(minimum * achievableTargetGrams)}`);
+    lines.push(` ${macro}_maximum: ${expression} <= ${formatNumber(maximum * achievableTargetGrams)}`);
+  }
+
+  for (const category of categoryKeys) {
+    const [minimum, maximum] = request.categoryRanges[category];
+    const expression = formatExpression(candidates.filter((candidate) => candidate.category === category).map(({ quantityVariable }) => ({ coefficient: 1, variable: quantityVariable })));
+    lines.push(` ${category}_minimum: ${expression} >= ${formatNumber((minimum / 100) * achievableTargetGrams)}`);
+    lines.push(` ${category}_maximum: ${expression} <= ${formatNumber((maximum / 100) * achievableTargetGrams)}`);
+  }
+
+  for (const candidate of candidates) {
+    lines.push(` maximum_share_${candidate.id}: ${candidate.quantityVariable} - M <= 0`);
+    if (candidate.meaningfulInclusionVariable) {
+      const inactiveMaximum = policy.meaningfulInclusionGrams - policy.gramIncrement;
+      const activeAllowance = candidate.availableGrams - policy.meaningfulInclusionGrams + policy.gramIncrement;
+      lines.push(` meaningful_lower_${candidate.id}: ${candidate.quantityVariable} - ${formatNumber(policy.meaningfulInclusionGrams)} ${candidate.meaningfulInclusionVariable} >= 0`);
+      lines.push(` meaningful_upper_${candidate.id}: ${candidate.quantityVariable} - ${formatNumber(activeAllowance)} ${candidate.meaningfulInclusionVariable} <= ${formatNumber(inactiveMaximum)}`);
+    }
+  }
+
+  lines.push("Bounds");
+  for (const candidate of candidates) lines.push(` 0 <= ${candidate.quantityVariable} <= ${formatNumber(candidate.availableGrams)}`);
+  lines.push(` 0 <= M <= ${formatNumber(achievableTargetGrams)}`);
+  lines.push("Generals");
+  lines.push(...candidates.map(({ quantityVariable }) => ` ${quantityVariable}`));
+  const meaningfulVariables = candidates.flatMap(({ meaningfulInclusionVariable }) => meaningfulInclusionVariable ? [meaningfulInclusionVariable] : []);
+  if (meaningfulVariables.length > 0) {
+    lines.push("Binaries");
+    lines.push(...meaningfulVariables.map((variable) => ` ${variable}`));
+  }
+  lines.push("End");
+
+  return { lp: lines.join("\n"), candidates, achievableTargetGrams, policy };
+}

--- a/v3-webapp/client/src/lib/optimizer-policy.ts
+++ b/v3-webapp/client/src/lib/optimizer-policy.ts
@@ -1,0 +1,11 @@
+export const OPTIMIZER_POLICY = {
+  gramIncrement: 1,
+  meaningfulInclusionGrams: 5,
+  exactMarginTolerance: 0,
+  macroDistanceTolerance: 0,
+  categoryDistanceTolerance: 0,
+  maximumShareToleranceGrams: 0,
+  canonicalCandidateOrder: "ingredient_id_ascending",
+} as const;
+
+export type OptimizerPolicy = typeof OPTIMIZER_POLICY;

--- a/v3-webapp/package.json
+++ b/v3-webapp/package.json
@@ -19,6 +19,7 @@
     "test:profile-default-formulas": "tsx scripts/verify-profile-default-formulas.mjs",
     "test:care-guidance": "tsx scripts/verify-care-guidance.mjs",
     "test:constrained-solver-poc": "tsx scripts/verify-constrained-solver-poc.mjs",
+    "test:optimizer-model": "vitest run src/lib/optimizer-model.test.ts",
     "test:issue-submission": "tsx scripts/verify-issue-submission.mjs",
     "test:github-app": "tsx scripts/verify-github-app-auth.mjs",
     "test:report-queue": "vitest run --config scripts/vitest.config.ts",

--- a/v3-webapp/todo.md
+++ b/v3-webapp/todo.md
@@ -120,3 +120,4 @@
 - [x] Upgrade the merged Firebase Admin production path and verify the reconciled report processor dependency graph has no known advisories.
 - [x] Implement and validate the Issue #134 attribute-aware lentil provenance model: purely split forms inherit base lentil nutrition and suitability; only material processing states create separate evidence boundaries; no runtime/catalog change.
 - [x] Build and validate the Issue #125 development-only constrained-solver proof of concept with pinned HiGHS, real active-data fixtures, safety-gate checks, deterministic reference coverage, and no runtime or public-copy change.
+- [x] Implement and validate Issue #137’s non-runtime optimizer policy and deterministic CPLEX-LP model builder without importing the active calculator or changing visible behavior.


### PR DESCRIPTION
Relates to #137

## Scope
Adds pure policy constants and a deterministic CPLEX-LP exact-feasibility model builder. The builder accepts already-gated candidates, uses active fixture data only in tests, emits named constraints, and does not import calculator runtime modules.

## Validation
Focused policy/model tests passed, including a real active Chicken/Pet LP accepted by pinned HiGHS. The complete calculator, care-guidance, provenance, type, server, production-build, and whitespace suites passed.

## Non-changes
No UI, runtime calculator integration, solver Worker registration, formula, active ingredient, safety rule, visitor inventory behavior, public copy, Firebase setting, or Firestore region change.

## Dependency and decision
This PR is stacked on #136 and should be reviewed after it. It preserves model-building evidence only; it does not authorize a runtime solver.