### PR TITLE
feat(optimizer): add worker lifecycle proof

### DIFF
--- a/v3-webapp/client/src/lib/optimizer-worker-controller.test.ts
+++ b/v3-webapp/client/src/lib/optimizer-worker-controller.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { OptimizerWorkerController, type OptimizerWorkerTransport } from "./optimizer-worker-controller";
+
+const request = {
+  type: "solve" as const,
+  requestId: "request-1",
+  model: { lp: "Minimize\n proof: 0\nEnd", candidates: [], achievableTargetGrams: 1, policy: { gramIncrement: 1, meaningfulInclusionGrams: 5, exactMarginTolerance: 0, macroDistanceTolerance: 0, categoryDistanceTolerance: 0, maximumShareToleranceGrams: 0, canonicalCandidateOrder: "ingredient_id_ascending" as const } },
+  createdAtMs: 0,
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => { resolve = nextResolve; });
+  return { promise, resolve };
+}
+
+describe("isolated optimizer worker lifecycle controller", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("posts one deterministic terminal optimal response", async () => {
+    const messages: unknown[] = [];
+    const controller = new OptimizerWorkerController(
+      { postMessage: (message) => messages.push(message) },
+      async () => ({ status: "optimal", quantities: { wheat: 1 }, solverStatus: "Optimal", mipGap: 0 }),
+      100,
+    );
+
+    controller.receive(request);
+    await Promise.resolve();
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({ type: "result", requestId: "request-1", status: "optimal", quantities: { wheat: 1 } });
+  });
+
+  it("posts cancellation once and suppresses a late solver completion", async () => {
+    const messages: unknown[] = [];
+    const pending = deferred<{ status: "optimal"; quantities: Record<string, number> }>();
+    const controller = new OptimizerWorkerController(
+      { postMessage: (message) => messages.push(message) },
+      async () => pending.promise,
+      100,
+    );
+
+    controller.receive(request);
+    controller.receive({ type: "cancel", requestId: "request-1" });
+    pending.resolve({ status: "optimal", quantities: { wheat: 1 } });
+    await Promise.resolve();
+
+    expect(messages).toEqual([{ type: "cancelled", requestId: "request-1" }]);
+  });
+
+  it("returns explicit malformed and duplicate-request errors", async () => {
+    const messages: unknown[] = [];
+    const pending = deferred<{ status: "optimal"; quantities: Record<string, number> }>();
+    const controller = new OptimizerWorkerController(
+      { postMessage: (message) => messages.push(message) },
+      async () => pending.promise,
+      100,
+    );
+
+    controller.receive({ not: "a request" });
+    controller.receive(request);
+    controller.receive(request);
+    controller.cancel("request-1");
+
+    expect(messages).toEqual([
+      expect.objectContaining({ requestId: "invalid-request", status: "error", errorMessage: "Malformed optimizer worker message" }),
+      expect.objectContaining({ requestId: "request-1", status: "error", errorMessage: "Duplicate optimizer worker request id" }),
+      { type: "cancelled", requestId: "request-1" },
+    ]);
+  });
+
+  it("posts an explicit timeout and suppresses a late worker completion", async () => {
+    vi.useFakeTimers();
+    const messages: unknown[] = [];
+    const pending = deferred<{ status: "optimal"; quantities: Record<string, number> }>();
+    const transport: OptimizerWorkerTransport = { postMessage: (message) => messages.push(message) };
+    const controller = new OptimizerWorkerController(transport, async () => pending.promise, 10);
+
+    controller.receive(request);
+    await vi.advanceTimersByTimeAsync(10);
+    pending.resolve({ status: "optimal", quantities: { wheat: 1 } });
+    await Promise.resolve();
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({ type: "result", requestId: "request-1", status: "timeout", quantities: {} });
+  });
+});

--- a/v3-webapp/client/src/lib/optimizer-worker-controller.ts
+++ b/v3-webapp/client/src/lib/optimizer-worker-controller.ts
@@ -1,0 +1,164 @@
+import type { OptimizerWorkerCancelRequest, OptimizerWorkerRawResult, OptimizerWorkerRequest, OptimizerWorkerResponse, OptimizerWorkerSolveRequest } from "./optimizer-protocol";
+
+export interface OptimizerWorkerExecutorResult {
+  status: "optimal" | "infeasible" | "error";
+  quantities: Record<string, number>;
+  mipGap?: number;
+  solverStatus?: string;
+  errorMessage?: string;
+}
+
+export interface OptimizerWorkerExecutionContext {
+  isCancelled(): boolean;
+}
+
+export type OptimizerWorkerExecutor = (
+  request: OptimizerWorkerSolveRequest,
+  context: OptimizerWorkerExecutionContext,
+) => Promise<OptimizerWorkerExecutorResult>;
+
+export interface OptimizerWorkerTransport {
+  postMessage(message: OptimizerWorkerResponse): void;
+}
+
+export interface OptimizerWorkerScopeLike extends OptimizerWorkerTransport {
+  addEventListener(type: "message", listener: (event: { data: unknown }) => void): void;
+}
+
+interface ActiveRequest {
+  cancelled: boolean;
+  timedOut: boolean;
+  timeoutHandle: ReturnType<typeof setTimeout>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSolveRequest(value: unknown): value is OptimizerWorkerSolveRequest {
+  return isRecord(value)
+    && value.type === "solve"
+    && typeof value.requestId === "string"
+    && value.requestId.length > 0
+    && isRecord(value.model)
+    && typeof value.createdAtMs === "number";
+}
+
+function isCancelRequest(value: unknown): value is OptimizerWorkerCancelRequest {
+  return isRecord(value)
+    && value.type === "cancel"
+    && typeof value.requestId === "string"
+    && value.requestId.length > 0;
+}
+
+function elapsedSince(startedAtMs: number): number {
+  return Math.max(0, Date.now() - startedAtMs);
+}
+
+export class OptimizerWorkerController {
+  private readonly activeRequests = new Map<string, ActiveRequest>();
+
+  public constructor(
+    private readonly transport: OptimizerWorkerTransport,
+    private readonly execute: OptimizerWorkerExecutor,
+    private readonly timeoutMs: number,
+  ) {
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) throw new Error("worker timeout must be a positive finite number");
+  }
+
+  public receive(message: unknown): void {
+    if (isCancelRequest(message)) {
+      this.cancel(message.requestId);
+      return;
+    }
+    if (isSolveRequest(message)) {
+      void this.start(message);
+      return;
+    }
+    this.transport.postMessage({
+      type: "result",
+      requestId: "invalid-request",
+      status: "error",
+      quantities: {},
+      elapsedMs: 0,
+      errorMessage: "Malformed optimizer worker message",
+    });
+  }
+
+  public cancel(requestId: string): void {
+    const active = this.activeRequests.get(requestId);
+    if (!active) return;
+    active.cancelled = true;
+    clearTimeout(active.timeoutHandle);
+    this.activeRequests.delete(requestId);
+    this.transport.postMessage({ type: "cancelled", requestId });
+  }
+
+  public dispose(): void {
+    Array.from(this.activeRequests.keys()).forEach((requestId) => this.cancel(requestId));
+  }
+
+  private async start(request: OptimizerWorkerSolveRequest): Promise<void> {
+    if (this.activeRequests.has(request.requestId)) {
+      this.transport.postMessage({
+        type: "result",
+        requestId: request.requestId,
+        status: "error",
+        quantities: {},
+        elapsedMs: 0,
+        errorMessage: "Duplicate optimizer worker request id",
+      });
+      return;
+    }
+
+    const startedAtMs = Date.now();
+    const active: ActiveRequest = {
+      cancelled: false,
+      timedOut: false,
+      timeoutHandle: setTimeout(() => {
+        const current = this.activeRequests.get(request.requestId);
+        if (!current || current.cancelled) return;
+        current.timedOut = true;
+        this.activeRequests.delete(request.requestId);
+        this.transport.postMessage({
+          type: "result",
+          requestId: request.requestId,
+          status: "timeout",
+          quantities: {},
+          elapsedMs: elapsedSince(startedAtMs),
+          errorMessage: "Optimizer worker proof-of-concept timeout",
+        });
+      }, this.timeoutMs),
+    };
+    this.activeRequests.set(request.requestId, active);
+
+    try {
+      const outcome = await this.execute(request, { isCancelled: () => active.cancelled || active.timedOut });
+      if (active.cancelled || active.timedOut || this.activeRequests.get(request.requestId) !== active) return;
+      clearTimeout(active.timeoutHandle);
+      this.activeRequests.delete(request.requestId);
+      this.transport.postMessage({
+        type: "result",
+        requestId: request.requestId,
+        elapsedMs: elapsedSince(startedAtMs),
+        ...outcome,
+      });
+    } catch (error) {
+      if (active.cancelled || active.timedOut || this.activeRequests.get(request.requestId) !== active) return;
+      clearTimeout(active.timeoutHandle);
+      this.activeRequests.delete(request.requestId);
+      this.transport.postMessage({
+        type: "result",
+        requestId: request.requestId,
+        status: "error",
+        quantities: {},
+        elapsedMs: elapsedSince(startedAtMs),
+        errorMessage: error instanceof Error ? error.message : "Unknown optimizer worker error",
+      });
+    }
+  }
+}
+
+export function installOptimizerWorkerScope(scope: OptimizerWorkerScopeLike, controller: OptimizerWorkerController): void {
+  scope.addEventListener("message", (event) => controller.receive(event.data as OptimizerWorkerRequest));
+}

--- a/v3-webapp/client/src/lib/optimizer-worker.ts
+++ b/v3-webapp/client/src/lib/optimizer-worker.ts
@@ -1,0 +1,16 @@
+import { OptimizerWorkerController, installOptimizerWorkerScope, type OptimizerWorkerScopeLike } from "./optimizer-worker-controller";
+
+const scope = globalThis as unknown as OptimizerWorkerScopeLike;
+
+if (typeof scope.addEventListener === "function" && typeof scope.postMessage === "function") {
+  const controller = new OptimizerWorkerController(
+    scope,
+    async () => ({
+      status: "error",
+      quantities: {},
+      errorMessage: "The isolated optimizer worker lifecycle proof of concept has no registered solver executor.",
+    }),
+    1_000,
+  );
+  installOptimizerWorkerScope(scope, controller);
+}

--- a/v3-webapp/package.json
+++ b/v3-webapp/package.json
@@ -22,6 +22,7 @@
     "test:optimizer-model": "vitest run src/lib/optimizer-model.test.ts",
     "test:optimizer-adapter": "vitest run src/lib/optimizer-adapter.test.ts",
     "test:optimizer-stages": "vitest run src/lib/optimizer-stages.test.ts",
+    "test:optimizer-worker": "vitest run src/lib/optimizer-worker-controller.test.ts",
     "test:issue-submission": "tsx scripts/verify-issue-submission.mjs",
     "test:github-app": "tsx scripts/verify-github-app-auth.mjs",
     "test:report-queue": "vitest run --config scripts/vitest.config.ts",

--- a/v3-webapp/todo.md
+++ b/v3-webapp/todo.md
@@ -123,3 +123,4 @@
 - [x] Implement and validate Issue #137’s non-runtime optimizer policy and deterministic CPLEX-LP model builder without importing the active calculator or changing visible behavior.
 - [x] Implement and validate Issue #138’s serializable solver protocol and strict result adapter without adding a browser Worker, calculator integration, visible output, or public-copy change.
 - [x] Implement and validate Issue #139’s deterministic serial objective-lock and structured infeasibility-evidence foundations without changing runtime behavior or visitor-visible output.
+- [x] Implement and validate Issue #140’s isolated browser-worker lifecycle controller without registering it in the calculator or changing visible behavior.


### PR DESCRIPTION
Relates to #140

## Scope
Adds an isolated, unregistered Worker lifecycle controller and Worker-only entry point. The controller covers serializable request validation, duplicate IDs, cancellation, timeout, late completion suppression, and terminal error states.

## Validation
Focused worker lifecycle tests passed. The complete stacked solver, calculator, care-guidance, provenance, type, server, production-build, and whitespace suites passed.

## Non-changes
The calculator does not import or register this Worker. The Worker entry has no HiGHS executor, so it cannot change calculator output or bundle behavior. No UI, formula, active data, safety rule, visitor inventory behavior, public copy, Firebase setting, or Firestore region changes.

## Dependency and decision
This PR is stacked on #139, #138, #137, and #136. Production asset strategy, real solver loading, browser support/performance evidence, timeout/incumbent display, and integration remain separately owner-reviewed.