### PR TITLE
feat(optimizer): register browser-local Worker executor

### DIFF
--- a/v3-webapp/client/src/lib/optimizer-runtime.test.ts
+++ b/v3-webapp/client/src/lib/optimizer-runtime.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { buildBrowserOptimizerCandidates, startBrowserLocalOptimizerSolve, type BrowserOptimizerWorker } from "./optimizer-runtime";
+
+class FakeWorker implements BrowserOptimizerWorker {
+  public readonly sent: unknown[] = [];
+  public onmessage: ((event: { data: unknown }) => void) | null = null;
+  public onerror: ((event: { message?: string }) => void) | null = null;
+  public terminated = false;
+
+  public postMessage(message: unknown): void {
+    this.sent.push(message);
+  }
+
+  public terminate(): void {
+    this.terminated = true;
+  }
+
+  public respond(data: unknown): void {
+    this.onmessage?.({ data });
+  }
+}
+
+const input = {
+  requestId: "browser-runtime-test",
+  bird: "chicken" as const,
+  inventory: { barley: 500, peas: 400, sunflower: 100 },
+  requestedTargetGrams: 1_000,
+  macroRanges: { protein: [0, 100], carbs: [0, 100], fat: [0, 100], fiber: [0, 100] } as const,
+  categoryRanges: { grain: [0, 100], legume: [0, 100], seed: [0, 100] } as const,
+};
+
+describe("browser-local optimizer runtime adapter", () => {
+  it("safety-gates original catalog keys before aggregating split lentils into one canonical candidate", () => {
+    const candidates = buildBrowserOptimizerCandidates({ lentils: 275, split_lentils: 125, kidney_beans: 500 }, "chicken");
+
+    expect(candidates).toEqual([{
+      id: "lentils",
+      category: "legume",
+      availableGrams: 400,
+      nutrition: { protein: 25, carbs: 63, fat: 1, fiber: 8 },
+      safetyState: "eligible",
+      sourceIngredientIds: ["lentils", "split_lentils"],
+    }]);
+  });
+
+  it("connects a matching Worker optimum to the strict result adapter and terminates the local Worker", async () => {
+    const worker = new FakeWorker();
+    const handle = startBrowserLocalOptimizerSolve(input, { createWorker: () => worker });
+
+    const solveMessage = worker.sent[0] as { model: { candidates: Array<{ id: string }> } };
+    expect(solveMessage.model.candidates.map(({ id }) => id)).toEqual(["barley", "peas", "sunflower"]);
+    worker.respond({
+      type: "result",
+      requestId: input.requestId,
+      status: "optimal",
+      quantities: { barley: 500, peas: 400, sunflower: 100 },
+      elapsedMs: 8,
+      solverStatus: "Optimal",
+    });
+
+    await expect(handle.result).resolves.toMatchObject({ status: "feasible", mix: { barley: 500, peas: 400, sunflower: 100 } });
+    expect(worker.terminated).toBe(true);
+  });
+
+  it("preserves a validated non-feasible status instead of manufacturing an alternative mix", async () => {
+    const worker = new FakeWorker();
+    const handle = startBrowserLocalOptimizerSolve(input, { createWorker: () => worker });
+    worker.respond({ type: "result", requestId: input.requestId, status: "timeout", quantities: {}, elapsedMs: 500, errorMessage: "time budget" });
+
+    await expect(handle.result).resolves.toMatchObject({ status: "timeout", mix: {} });
+  });
+
+  it("sends cancellation to the Worker and accepts only its matching cancellation acknowledgement", async () => {
+    const worker = new FakeWorker();
+    const handle = startBrowserLocalOptimizerSolve(input, { createWorker: () => worker });
+    handle.cancel();
+    expect(worker.sent.at(-1)).toEqual({ type: "cancel", requestId: input.requestId });
+    worker.respond({ type: "cancelled", requestId: input.requestId });
+
+    await expect(handle.result).resolves.toMatchObject({ status: "cancelled", mix: {} });
+  });
+});

--- a/v3-webapp/client/src/lib/optimizer-runtime.ts
+++ b/v3-webapp/client/src/lib/optimizer-runtime.ts
@@ -1,0 +1,164 @@
+import { adaptExactFeasibilityResult, type AdaptedOptimizerResult } from "./optimizer-adapter";
+import { checkBirdToxicity, isIngredientCompatible } from "./bird-safety";
+import type { BirdType } from "./birds";
+import { INGREDIENTS } from "./data";
+import { canonicalizeOptimizerCandidates } from "./optimizer-ingredient-identity";
+import { buildExactFeasibilityModel, type OptimizerCategory, type OptimizerMacro, type OptimizerRange } from "./optimizer-model";
+import type { OptimizerWorkerRawResult, OptimizerWorkerResponse } from "./optimizer-protocol";
+import { isToxicRaw, requiresVerifiedProcessing } from "./safety";
+
+export interface BrowserOptimizerSolveInput {
+  requestId: string;
+  bird: BirdType;
+  inventory: Readonly<Record<string, number>>;
+  requestedTargetGrams: number;
+  macroRanges: Record<OptimizerMacro, OptimizerRange>;
+  categoryRanges: Record<OptimizerCategory, OptimizerRange>;
+}
+
+export interface BrowserOptimizerWorker {
+  postMessage(message: unknown): void;
+  terminate(): void;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  onerror: ((event: { message?: string }) => void) | null;
+}
+
+export interface BrowserOptimizerRuntimeOptions {
+  createWorker?: () => BrowserOptimizerWorker;
+}
+
+export interface BrowserOptimizerSolveHandle {
+  result: Promise<AdaptedOptimizerResult>;
+  cancel(): void;
+}
+
+function createDefaultWorker(): BrowserOptimizerWorker {
+  return new Worker(new URL("./optimizer-worker.ts", import.meta.url), { type: "module" }) as unknown as BrowserOptimizerWorker;
+}
+
+function rawResult(
+  requestId: string,
+  status: OptimizerWorkerRawResult["status"],
+  errorMessage?: string,
+): OptimizerWorkerRawResult {
+  return {
+    type: "result",
+    requestId,
+    status,
+    quantities: {},
+    elapsedMs: 0,
+    ...(errorMessage ? { errorMessage } : {}),
+  };
+}
+
+function isRawResult(value: unknown): value is OptimizerWorkerRawResult {
+  return typeof value === "object"
+    && value !== null
+    && (value as { type?: unknown }).type === "result"
+    && typeof (value as { requestId?: unknown }).requestId === "string"
+    && typeof (value as { status?: unknown }).status === "string"
+    && typeof (value as { elapsedMs?: unknown }).elapsedMs === "number"
+    && typeof (value as { quantities?: unknown }).quantities === "object";
+}
+
+/**
+ * Builds Worker candidates from actual entered inventory only. Safety gates run
+ * on each original catalog key before aliases aggregate, so canonicalization
+ * cannot elevate a disallowed form into a safe solver candidate.
+ */
+export function buildBrowserOptimizerCandidates(
+  inventory: Readonly<Record<string, number>>,
+  bird: BirdType,
+) {
+  const safeCandidates = Object.entries(inventory)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .flatMap(([id, availableGrams]) => {
+      const ingredient = INGREDIENTS[id];
+      if (!ingredient || !Number.isFinite(availableGrams) || availableGrams <= 0) return [];
+      if (
+        !isIngredientCompatible(id, bird)
+        || checkBirdToxicity(id, bird)
+        || isToxicRaw(id)
+        || requiresVerifiedProcessing(id)
+      ) {
+        return [];
+      }
+      return [{
+        id,
+        category: ingredient.category,
+        availableGrams: Math.floor(availableGrams),
+        nutrition: {
+          protein: ingredient.protein,
+          carbs: ingredient.carbs,
+          fat: ingredient.fat,
+          fiber: ingredient.fiber,
+        },
+        safetyState: "eligible" as const,
+      }];
+    });
+
+  return canonicalizeOptimizerCandidates(safeCandidates);
+}
+
+/**
+ * Creates but does not automatically invoke the browser-local solver. Home.tsx
+ * continues using its present synchronous calculator output until a later,
+ * separately reviewed display-integration change calls this adapter.
+ */
+export function startBrowserLocalOptimizerSolve(
+  input: BrowserOptimizerSolveInput,
+  options: BrowserOptimizerRuntimeOptions = {},
+): BrowserOptimizerSolveHandle {
+  const candidates = buildBrowserOptimizerCandidates(input.inventory, input.bird);
+  const model = buildExactFeasibilityModel({
+    candidates,
+    requestedTargetGrams: input.requestedTargetGrams,
+    macroRanges: input.macroRanges,
+    categoryRanges: input.categoryRanges,
+  });
+  const worker = (options.createWorker ?? createDefaultWorker)();
+  let settled = false;
+
+  let resolveResult: (result: AdaptedOptimizerResult) => void = () => undefined;
+  const result = new Promise<AdaptedOptimizerResult>((resolve) => {
+    resolveResult = resolve;
+  });
+
+  const finish = (raw: OptimizerWorkerRawResult): void => {
+    if (settled) return;
+    settled = true;
+    worker.terminate();
+    resolveResult(adaptExactFeasibilityResult(
+      raw,
+      model,
+      input.requestedTargetGrams,
+      input.macroRanges,
+      input.categoryRanges,
+    ));
+  };
+
+  worker.onmessage = (event) => {
+    const response = event.data as OptimizerWorkerResponse;
+    if (response.type === "cancelled" && response.requestId === input.requestId) {
+      finish(rawResult(input.requestId, "cancelled"));
+      return;
+    }
+    if (isRawResult(response) && response.requestId === input.requestId) finish(response);
+  };
+  worker.onerror = (event) => finish(rawResult(input.requestId, "error", event.message || "Browser optimizer worker error"));
+  worker.postMessage({
+    type: "solve",
+    requestId: input.requestId,
+    model,
+    createdAtMs: Date.now(),
+  });
+
+  return {
+    result,
+    cancel: () => {
+      if (settled) return;
+      worker.postMessage({ type: "cancel", requestId: input.requestId });
+    },
+  };
+}
+

--- a/v3-webapp/client/src/lib/optimizer-worker-controller.ts
+++ b/v3-webapp/client/src/lib/optimizer-worker-controller.ts
@@ -1,7 +1,7 @@
 import type { OptimizerWorkerCancelRequest, OptimizerWorkerRawResult, OptimizerWorkerRequest, OptimizerWorkerResponse, OptimizerWorkerSolveRequest } from "./optimizer-protocol";
 
 export interface OptimizerWorkerExecutorResult {
-  status: "optimal" | "infeasible" | "error";
+  status: OptimizerWorkerRawResult["status"];
   quantities: Record<string, number>;
   mipGap?: number;
   solverStatus?: string;

--- a/v3-webapp/client/src/lib/optimizer-worker-executor.test.ts
+++ b/v3-webapp/client/src/lib/optimizer-worker-executor.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { buildExactFeasibilityModel } from "./optimizer-model";
+import { createBrowserLocalSolverExecutor } from "./optimizer-worker-executor";
+
+const model = buildExactFeasibilityModel({
+  candidates: [
+    { id: "barley", category: "grain", availableGrams: 500, nutrition: { protein: 11, carbs: 73, fat: 2, fiber: 5 }, safetyState: "eligible" },
+    { id: "peas", category: "legume", availableGrams: 500, nutrition: { protein: 23, carbs: 60, fat: 1.5, fiber: 5 }, safetyState: "eligible" },
+    { id: "sunflower", category: "seed", availableGrams: 500, nutrition: { protein: 20, carbs: 20, fat: 51, fiber: 9 }, safetyState: "eligible" },
+  ],
+  requestedTargetGrams: 1_000,
+  macroRanges: { protein: [0, 100], carbs: [0, 100], fat: [0, 100], fiber: [0, 100] },
+  categoryRanges: { grain: [0, 100], legume: [0, 100], seed: [0, 100] },
+});
+
+function request() {
+  return { type: "solve" as const, requestId: "runtime-test", model, createdAtMs: 0 };
+}
+
+describe("browser-local optimizer Worker executor", () => {
+  it("loads the local wasm resolver once and returns named raw quantities for an optimal solve", async () => {
+    const locateFiles: string[] = [];
+    let loadCount = 0;
+    const executor = createBrowserLocalSolverExecutor({
+      loadHighs: async ({ locateFile }) => {
+        loadCount += 1;
+        locateFiles.push(locateFile("highs.wasm"));
+        return {
+          solve: () => ({
+            Status: "Optimal",
+            Columns: {
+              barley: { Primal: 500 },
+              peas: { Primal: 400 },
+              sunflower: { Primal: 100 },
+            },
+          }),
+        };
+      },
+    });
+
+    const first = await executor(request(), { isCancelled: () => false });
+    const second = await executor({ ...request(), requestId: "runtime-test-2" }, { isCancelled: () => false });
+
+    expect(first).toMatchObject({ status: "optimal", quantities: { barley: 500, peas: 400, sunflower: 100 }, solverStatus: "Optimal" });
+    expect(second.status).toBe("optimal");
+    expect(loadCount).toBe(1);
+    expect(locateFiles[0]).toMatch(/highs\.wasm/);
+  });
+
+  it("maps infeasible, bounded-time, and unsupported solver statuses without manufacturing quantities", async () => {
+    for (const [highsStatus, expectedStatus] of [
+      ["Infeasible", "infeasible"],
+      ["Time limit reached", "timeout"],
+      ["Unknown", "error"],
+    ] as const) {
+      const executor = createBrowserLocalSolverExecutor({
+        loadHighs: async () => ({ solve: () => ({ Status: highsStatus, Columns: {} }) }),
+      });
+      const result = await executor(request(), { isCancelled: () => false });
+      expect(result.status).toBe(expectedStatus);
+      expect(result.quantities).toEqual({});
+    }
+  });
+
+  it("does not load or solve after cancellation", async () => {
+    let loaded = false;
+    const executor = createBrowserLocalSolverExecutor({
+      loadHighs: async () => {
+        loaded = true;
+        throw new Error("should not load");
+      },
+    });
+
+    await expect(executor(request(), { isCancelled: () => true })).resolves.toMatchObject({ status: "cancelled", quantities: {} });
+    expect(loaded).toBe(false);
+  });
+});

--- a/v3-webapp/client/src/lib/optimizer-worker-executor.ts
+++ b/v3-webapp/client/src/lib/optimizer-worker-executor.ts
@@ -1,0 +1,91 @@
+import highsLoader from "highs";
+import highsWasmUrl from "highs/runtime?url";
+
+import type { OptimizerModel } from "./optimizer-model";
+import type { OptimizerWorkerExecutor, OptimizerWorkerExecutorResult } from "./optimizer-worker-controller";
+
+export const BROWSER_SOLVER_TIME_LIMIT_MS = 500;
+export const BROWSER_WORKER_WALL_TIMEOUT_MS = 1_000;
+
+interface HighsColumn {
+  Primal: number;
+}
+
+interface HighsSolution {
+  Status: string;
+  Columns: Record<string, HighsColumn | undefined>;
+}
+
+interface HighsSolver {
+  solve(problem: string, options: {
+    time_limit: number;
+    threads: number;
+    parallel: "off";
+    output_flag: false;
+    log_to_console: false;
+  }): HighsSolution;
+}
+
+type HighsLoader = (options: { locateFile(file: string): string }) => Promise<HighsSolver>;
+
+export interface BrowserSolverExecutorOptions {
+  loadHighs?: HighsLoader;
+  timeLimitMs?: number;
+}
+
+function mapSolutionStatus(status: string): OptimizerWorkerExecutorResult["status"] {
+  if (status === "Optimal") return "optimal";
+  if (status === "Infeasible") return "infeasible";
+  if (status === "Time limit reached") return "timeout";
+  return "error";
+}
+
+function quantitiesFromSolution(solution: HighsSolution, model: OptimizerModel): Record<string, number> {
+  return Object.fromEntries(model.candidates.map(({ id }) => [id, solution.Columns[id]?.Primal ?? Number.NaN]));
+}
+
+/**
+ * Creates an executor intended only for a dedicated browser Worker. The wasm
+ * locator points to a Vite-managed local asset; it never calls Firebase or a
+ * third-party solver endpoint. The HiGHS time limit is an in-solver bound,
+ * while the controller retains the independent wall-clock cancellation guard.
+ */
+export function createBrowserLocalSolverExecutor(options: BrowserSolverExecutorOptions = {}): OptimizerWorkerExecutor {
+  const timeLimitMs = options.timeLimitMs ?? BROWSER_SOLVER_TIME_LIMIT_MS;
+  if (!Number.isFinite(timeLimitMs) || timeLimitMs <= 0) throw new Error("browser solver time limit must be positive and finite");
+
+  const loadHighs: HighsLoader = options.loadHighs ?? ((settings) => highsLoader(settings) as Promise<HighsSolver>);
+  let solverPromise: Promise<HighsSolver> | undefined;
+  const getSolver = (): Promise<HighsSolver> => {
+    solverPromise ??= loadHighs({
+      locateFile: (file) => file.endsWith(".wasm") ? highsWasmUrl : file,
+    });
+    return solverPromise;
+  };
+
+  return async (request, context): Promise<OptimizerWorkerExecutorResult> => {
+    if (context.isCancelled()) return { status: "cancelled", quantities: {}, errorMessage: "Optimizer solve was cancelled before execution" };
+
+    const solver = await getSolver();
+    if (context.isCancelled()) return { status: "cancelled", quantities: {}, errorMessage: "Optimizer solve was cancelled before execution" };
+
+    const solution = solver.solve(request.model.lp, {
+      time_limit: timeLimitMs / 1_000,
+      threads: 1,
+      parallel: "off",
+      output_flag: false,
+      log_to_console: false,
+    });
+    if (context.isCancelled()) return { status: "cancelled", quantities: {}, solverStatus: solution.Status, errorMessage: "Optimizer solve was cancelled" };
+
+    const status = mapSolutionStatus(solution.Status);
+    const quantities = status === "optimal" ? quantitiesFromSolution(solution, request.model) : {};
+    return {
+      status,
+      quantities,
+      solverStatus: solution.Status,
+      ...(status === "error" ? { errorMessage: `HiGHS returned unsupported status '${solution.Status}'` } : {}),
+    };
+  };
+}
+

--- a/v3-webapp/client/src/lib/optimizer-worker.ts
+++ b/v3-webapp/client/src/lib/optimizer-worker.ts
@@ -1,16 +1,13 @@
 import { OptimizerWorkerController, installOptimizerWorkerScope, type OptimizerWorkerScopeLike } from "./optimizer-worker-controller";
+import { BROWSER_WORKER_WALL_TIMEOUT_MS, createBrowserLocalSolverExecutor } from "./optimizer-worker-executor";
 
 const scope = globalThis as unknown as OptimizerWorkerScopeLike;
 
 if (typeof scope.addEventListener === "function" && typeof scope.postMessage === "function") {
   const controller = new OptimizerWorkerController(
     scope,
-    async () => ({
-      status: "error",
-      quantities: {},
-      errorMessage: "The isolated optimizer worker lifecycle proof of concept has no registered solver executor.",
-    }),
-    1_000,
+    createBrowserLocalSolverExecutor(),
+    BROWSER_WORKER_WALL_TIMEOUT_MS,
   );
   installOptimizerWorkerScope(scope, controller);
 }

--- a/v3-webapp/package.json
+++ b/v3-webapp/package.json
@@ -23,6 +23,7 @@
     "test:optimizer-adapter": "vitest run src/lib/optimizer-adapter.test.ts",
     "test:optimizer-stages": "vitest run src/lib/optimizer-stages.test.ts",
     "test:optimizer-worker": "vitest run src/lib/optimizer-worker-controller.test.ts",
+    "test:optimizer-browser-bundle": "vite build --config scripts/vite.optimizer-worker.config.ts",
     "test:optimizer-identity": "vitest run src/lib/optimizer-ingredient-identity.test.ts",
     "test:issue-submission": "tsx scripts/verify-issue-submission.mjs",
     "test:github-app": "tsx scripts/verify-github-app-auth.mjs",

--- a/v3-webapp/scripts/vite.optimizer-worker.config.ts
+++ b/v3-webapp/scripts/vite.optimizer-worker.config.ts
@@ -1,0 +1,15 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  root: resolve(import.meta.dirname, "../client"),
+  build: {
+    emptyOutDir: true,
+    lib: {
+      entry: resolve(import.meta.dirname, "../client/src/lib/optimizer-worker.ts"),
+      formats: ["es"],
+      fileName: "optimizer-worker",
+    },
+    outDir: resolve(import.meta.dirname, "../../../worker-bundle-proof"),
+  },
+});

--- a/v3-webapp/todo.md
+++ b/v3-webapp/todo.md
@@ -125,3 +125,4 @@
 - [x] Implement and validate Issue #139’s deterministic serial objective-lock and structured infeasibility-evidence foundations without changing runtime behavior or visitor-visible output.
 - [x] Implement and validate Issue #140’s isolated browser-worker lifecycle controller without registering it in the calculator or changing visible behavior.
 - [x] Implement and validate Issue #148’s canonical split-lentil solver identity while preserving the visible catalog record, existing inventory keys, formulas, and public copy.
+- [x] Implement and validate Issue #151’s browser-local Worker executor, bounded solve protocol, strict result validation, and no-server-compute boundary without changing visitor-facing copy or current output defaults.


### PR DESCRIPTION
Closes #151

## Scope

This stacked runtime slice replaces the Worker proof placeholder with a local HiGHS/WebAssembly executor. It creates a Worker-facing runtime adapter that derives safety-gated candidates, canonicalizes split lentils through #149, builds the exact model, posts it to the dedicated Worker, and passes only terminal raw output through the strict result adapter.

The Worker resolves the package runtime through a Vite-managed local asset URL. It uses an in-solver 500 ms time limit, a separate 1,000 ms Worker wall-clock guard, browser-side cancellation, and a one-thread/serial solver configuration. No request is sent to Firebase, Cloud Functions, Cloud Run, Firestore, or a third-party solver service.

## Validation

- 11 focused executor/runtime/controller tests passed.
- Browser Worker Vite build passed: a static local Worker bundle was emitted at 4,653,926 bytes (1,652,600 bytes gzip). Bundle inspection found no external solver endpoint.
- Solver identity, model, adapter, serial-stage, controller, constrained-solver corpus, calculator, care-guidance, provenance, TypeScript, server, production-build, and whitespace checks passed.

## Dependencies

This PR is stacked on #149, which supplies the approved split-lentil canonical identity. Merge #149 first, then rebase and validate this PR before a merge decision.

## What did not change

No calculator page imports this runtime adapter yet, so current visitor-visible formula output and wording remain unchanged. No active catalog row, inventory key, formula, safety rule, visible catalog entry, Firebase setting, Firestore region, server route, Cloud Function, Cloud Run service, or public-facing string changed.

## Owner decision after this foundation

The executor is ready, but displaying an optimized canonical result requires a follow-on behavior decision: how a canonical lentil quantity should be allocated back to the visitor's actual whole/split inventory keys when both forms are supplied, and what current UI behavior should occur for pending, timeout, infeasible, or invalid solves. This PR deliberately retains the existing display until those boundaries are reviewed.