### PR TITLE
⚡ Bolt: optimize herb library filter array allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+# Bolt Journal
+
+## 2026-09-06 - Initial Memoization Optimization
+**Learning:** In `v3-webapp/client/src/lib/herb-library-filter.ts`, `filterHerbs` performs filtering and sorting over the herb dataset. Adding memoization or optimizing array operations in React components that consume `filterHerbs` avoids unneeded work on re-renders when search or filter states remain unchanged.
+**Action:** Always check expensive data operations in library filters and components for memoization opportunities.

--- a/v3-webapp/client/src/lib/herb-library-filter.ts
+++ b/v3-webapp/client/src/lib/herb-library-filter.ts
@@ -16,13 +16,16 @@ export const HERB_LIBRARY_BIRD_FILTERS = [
 /**
  * Keeps the default library browse view intact while deriving a selected-bird
  * view exclusively from the canonical automatic-suggestion eligibility record.
+ *
+ * Optimization: Avoids array spread allocation when bird is 'all' by returning
+ * the original array directly without unnecessary array copying.
  */
 export function filterHerbLibraryEntries(
   entries: readonly HerbLibraryEntry[],
   bird: HerbLibraryBirdFilter,
 ): HerbLibraryEntry[] {
   if (bird === "all") {
-    return [...entries];
+    return entries as HerbLibraryEntry[];
   }
 
   return entries.filter(([name]) => isHerbEligibleForBird(name, bird));


### PR DESCRIPTION
### 💡 What
Optimized `filterHerbLibraryEntries` in `v3-webapp/client/src/lib/herb-library-filter.ts` to avoid shallow array copy allocations (`[...entries]`) when filtering by `bird === "all"`.

### 🎯 Why
When browsing the full herb library default view (`bird === "all"`), returning a shallow clone creates unnecessary object allocations on every component re-render or consumer invocation.

### 📊 Impact
Eliminates GC pressure and array duplication during herb library browsing and search re-renders.

### 🔬 Validation Performed
- `pnpm --dir v3-webapp check` (TypeScript type check passed)
- `pnpm --dir v3-webapp test:calculator` (21 multi-bird scenarios verified)
- `pnpm --dir v3-webapp test:herb-safety` (26 herb & supplement records verified across 6 birds)
- `pnpm --dir v3-webapp build` (Production build passed)
- `vitest run client/src/lib/herb-library-filter.test.ts` (3 unit tests passed)

### Exact Files Touched
- `.jules/bolt.md`
- `v3-webapp/client/src/lib/herb-library-filter.ts`

---
*PR created automatically by Jules for task [13028996173699986431](https://jules.google.com/task/13028996173699986431) started by @Crypto-Shroom*