### PR TITLE
docs(provenance): link raw white beans in food coverage ledger (#92)

### DIFF
--- a/database/provenance/food-coverage.json
+++ b/database/provenance/food-coverage.json
@@ -271,7 +271,18 @@
           "id": "white-beans-raw",
           "displayName": "White beans",
           "historicalForm": "raw",
-          "linkedFoodReviewKeys": []
+          "linkedFoodReviewKeys": [
+            "great_northern_white_beans::raw dried Great Northern white beans, plain and unseasoned",
+            "cannellini_white_beans::raw dried cannellini white beans, plain and unseasoned"
+          ],
+          "selectedResearchForm": "raw dried white beans (Great Northern / Cannellini)",
+          "excludedForms": [
+            "raw/cooked/sprouted alternatives not matching the selected form",
+            "oils",
+            "extracts",
+            "blends",
+            "concentrated supplements"
+          ]
         },
         {
           "id": "large-dried-beans-raw",


### PR DESCRIPTION
### Summary & User Impact
This PR updates `database/provenance/food-coverage.json` as part of issue #92 (Provenance Ledger Reconciliation). It maps the tracked historical item `white-beans-raw` to its existing canonical six-bird evidence reviews (`great_northern_white_beans` and `cannellini_white_beans`).

**User Impact:** None / Non-runtime data mapping only. No active ingredients, nutrition targets, formulas, calculator behaviors, safety rules, or public-facing copy were altered.

### Files Touched
- `database/provenance/food-coverage.json`

### Concrete Changes
- **Before:** `white-beans-raw` under `historical-raw-legume-rules` had `linkedFoodReviewKeys: []`.
- **After:** `white-beans-raw` links to:
  - `"great_northern_white_beans::raw dried Great Northern white beans, plain and unseasoned"`
  - `"cannellini_white_beans::raw dried cannellini white beans, plain and unseasoned"`
  It also explicitly records `selectedResearchForm: "raw dried white beans (Great Northern / Cannellini)"` and standard `excludedForms`.

### Validation Performed
- `pnpm test:provenance` (runs `node database/tools/validate-provenance-ledger.mjs` and `vitest run src/lib/provenance-ledger.test.ts`) - **Passed (28/28 tests)**
- `pnpm --dir v3-webapp check` - **Passed**
- `pnpm --dir v3-webapp test:calculator` - **Passed (21 scenarios)**
- `pnpm --dir v3-webapp test:herb-safety` - **Passed (26 records)**
- `pnpm --dir v3-webapp build` - **Passed**

---
*PR created automatically by Jules for task [10409378064402478710](https://jules.google.com/task/10409378064402478710) started by @Crypto-Shroom*