### PR TITLE
fix: enable Firebase Functions TypeScript interop

### DIFF
--- a/v3-webapp/functions/tsconfig.json
+++ b/v3-webapp/functions/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "esModuleInterop": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "outDir": "lib",


### PR DESCRIPTION
## Summary
- enable `esModuleInterop` for the Firebase Functions TypeScript build
- fix the CI deployment failure introduced by `firebase-functions` v7 type declarations

## Validation
- `npm --prefix v3-webapp/functions ci --ignore-scripts`
- `npm --prefix v3-webapp/functions run build`

The previous main deployment failed with TS1259 in `firebase-functions/lib/common/providers/https.d.ts` because the Functions tsconfig did not enable CommonJS interop.