### PR TITLE
feat: canonicalize split_lentils as lentil alias for solver identity

### DIFF
--- a/v3-webapp/client/src/lib/optimizer-ingredient-identity.test.ts
+++ b/v3-webapp/client/src/lib/optimizer-ingredient-identity.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import { BIRD_PROFILES, getCategoryTargets } from "./birds";
 import { INGREDIENTS } from "./data";
-import { canonicalizeOptimizerCandidates, resolveSolverCanonicalIngredientId } from "./optimizer-ingredient-identity";
+import { assertCanonicalFormNutritionParity, canonicalizeOptimizerCandidates, resolveSolverCanonicalIngredientId } from "./optimizer-ingredient-identity";
 import { buildExactFeasibilityModel, type OptimizerCandidate } from "./optimizer-model";
 
 const rootPath = resolve(import.meta.dirname, "../../../../");
@@ -44,6 +44,24 @@ describe("canonical optimizer ingredient identity", () => {
     });
     expect(resolveSolverCanonicalIngredientId("split_lentils")).toBe("lentils");
     expect(resolveSolverCanonicalIngredientId("lentils")).toBe("lentils");
+    expect(resolveSolverCanonicalIngredientId("wheat")).toBe("wheat");
+    expect(resolveSolverCanonicalIngredientId("peas")).toBe("peas");
+    expect(() => assertCanonicalFormNutritionParity("split_lentils", "lentils")).not.toThrow();
+  });
+
+  it("canonicalizes split_lentils to lentils even when whole lentils are not in inventory", () => {
+    const canonical = canonicalizeOptimizerCandidates([
+      candidate("split_lentils", 150),
+    ]);
+
+    expect(canonical).toEqual([{
+      id: "lentils",
+      category: "legume",
+      availableGrams: 150,
+      nutrition: { protein: 25, carbs: 63, fat: 1, fiber: 8 },
+      safetyState: "eligible",
+      sourceIngredientIds: ["split_lentils"],
+    }]);
   });
 
   it("aggregates whole and split actual stock under one canonical solver candidate", () => {
@@ -85,5 +103,13 @@ describe("canonical optimizer ingredient identity", () => {
 
   it("does not use canonicalization to bypass a failed safety gate", () => {
     expect(() => canonicalizeOptimizerCandidates([candidate("split_lentils", 125, "excluded")])).toThrow("did not pass the safety gate");
+  });
+
+  it("throws an error when candidate has invalid available grams", () => {
+    const invalidCandidate = {
+      ...candidate("split_lentils", 100),
+      availableGrams: -10,
+    };
+    expect(() => canonicalizeOptimizerCandidates([invalidCandidate])).toThrow("invalid available grams");
   });
 });

--- a/v3-webapp/client/src/lib/optimizer-ingredient-identity.ts
+++ b/v3-webapp/client/src/lib/optimizer-ingredient-identity.ts
@@ -20,6 +20,20 @@ function assertCatalogIngredient(id: string): NonNullable<typeof INGREDIENTS[str
   return ingredient;
 }
 
+export function assertCanonicalFormNutritionParity(aliasId: string, canonicalId: string): void {
+  const alias = assertCatalogIngredient(aliasId);
+  const canonical = assertCatalogIngredient(canonicalId);
+  if (
+    alias.category !== canonical.category ||
+    alias.protein !== canonical.protein ||
+    alias.carbs !== canonical.carbs ||
+    alias.fat !== canonical.fat ||
+    alias.fiber !== canonical.fiber
+  ) {
+    throw new Error(`alias ingredient '${aliasId}' nutrition profile diverges from canonical ingredient '${canonicalId}'`);
+  }
+}
+
 function nutritionFor(id: string): Record<OptimizerMacro, number> {
   const ingredient = assertCatalogIngredient(id);
   return {
@@ -53,6 +67,9 @@ export function canonicalizeOptimizerCandidates(
     }
 
     const canonicalId = resolveSolverCanonicalIngredientId(candidate.id);
+    if (candidate.id !== canonicalId) {
+      assertCanonicalFormNutritionParity(candidate.id, canonicalId);
+    }
     const canonicalIngredient = assertCatalogIngredient(canonicalId);
     const existing = aggregated.get(canonicalId);
     const nextSourceIds = Array.from(new Set([...(existing?.sourceIngredientIds ?? []), candidate.id])).sort();


### PR DESCRIPTION
### User Impact
No visible UI catalog removal or inventory migration. When visitors use the feed optimizer with split lentils in inventory, the solver canonicalizes `split_lentils` to `lentils` so split lentils do not earn artificial separate diversity credit or duplicate solver variables.

### Files Touched
- `v3-webapp/client/src/lib/optimizer-ingredient-identity.ts`
- `v3-webapp/client/src/lib/optimizer-ingredient-identity.test.ts`

### Specific Changes Made
- Added `assertCanonicalFormNutritionParity` to runtime-validate nutrition and category parity between aliases and canonical ingredients before canonicalization.
- Verified deterministic mapping of `split_lentils` -> `lentils` in `resolveSolverCanonicalIngredientId` and candidate aggregation in `canonicalizeOptimizerCandidates`.
- Expanded unit tests covering active data reconciliation with provenance, single-alias inventory, combined whole/split inventory, invalid availableGrams, and safety gate enforcement.

Fixes #148

---
*PR created automatically by Jules for task [4288981523178371478](https://jules.google.com/task/4288981523178371478) started by @Crypto-Shroom*