### PR TITLE
test(optimizer): test browser worker lifecycle proof of concept

### DIFF
--- a/v3-webapp/client/src/lib/optimizer-worker-controller.test.ts
+++ b/v3-webapp/client/src/lib/optimizer-worker-controller.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { OptimizerWorkerController, type OptimizerWorkerTransport } from "./optimizer-worker-controller";
+import { installOptimizerWorkerScope, OptimizerWorkerController, type OptimizerWorkerScopeLike, type OptimizerWorkerTransport } from "./optimizer-worker-controller";
 
 const request = {
   type: "solve" as const,
@@ -85,5 +85,124 @@ describe("isolated optimizer worker lifecycle controller", () => {
 
     expect(messages).toHaveLength(1);
     expect(messages[0]).toMatchObject({ type: "result", requestId: "request-1", status: "timeout", quantities: {} });
+  });
+
+  it("handles executor errors and thrown exceptions deterministically", async () => {
+    const messages: unknown[] = [];
+    let throwError = false;
+    let throwNonError = false;
+
+    const controller = new OptimizerWorkerController(
+      { postMessage: (message) => messages.push(message) },
+      async () => {
+        if (throwError) throw new Error("Executor crashed");
+        if (throwNonError) throw "Non-error failure";
+        return { status: "error", quantities: {}, errorMessage: "Solver execution error" };
+      },
+      100,
+    );
+
+    controller.receive(request);
+    await Promise.resolve();
+
+    throwError = true;
+    controller.receive({ ...request, requestId: "request-2" });
+    await Promise.resolve();
+
+    throwError = false;
+    throwNonError = true;
+    controller.receive({ ...request, requestId: "request-3" });
+    await Promise.resolve();
+
+    expect(messages).toEqual([
+      expect.objectContaining({ requestId: "request-1", status: "error", errorMessage: "Solver execution error" }),
+      expect.objectContaining({ requestId: "request-2", status: "error", errorMessage: "Executor crashed" }),
+      expect.objectContaining({ requestId: "request-3", status: "error", errorMessage: "Unknown optimizer worker error" }),
+    ]);
+  });
+
+  it("supports request sequencing and requestId reuse after completion or cancellation", async () => {
+    const messages: unknown[] = [];
+    const controller = new OptimizerWorkerController(
+      { postMessage: (message) => messages.push(message) },
+      async (req) => ({ status: "optimal", quantities: { wheat: req.requestId === "req-1" ? 100 : 200 } }),
+      100,
+    );
+
+    // Sequential requests req-1, req-2
+    controller.receive({ ...request, requestId: "req-1" });
+    await Promise.resolve();
+
+    controller.receive({ ...request, requestId: "req-2" });
+    await Promise.resolve();
+
+    // Cancel req-3, then reuse req-3
+    const pending = deferred<{ status: "optimal"; quantities: Record<string, number> }>();
+    const cancelController = new OptimizerWorkerController(
+      { postMessage: (message) => messages.push(message) },
+      async () => pending.promise,
+      100,
+    );
+
+    cancelController.receive({ ...request, requestId: "req-3" });
+    cancelController.cancel("req-3");
+
+    // Reuse req-1 on initial controller
+    controller.receive({ ...request, requestId: "req-1" });
+    await Promise.resolve();
+
+    expect(messages).toEqual([
+      expect.objectContaining({ requestId: "req-1", status: "optimal", quantities: { wheat: 100 } }),
+      expect.objectContaining({ requestId: "req-2", status: "optimal", quantities: { wheat: 200 } }),
+      { type: "cancelled", requestId: "req-3" },
+      expect.objectContaining({ requestId: "req-1", status: "optimal", quantities: { wheat: 100 } }),
+    ]);
+  });
+
+  it("installs event listeners on scope and dispatches incoming messages to controller", () => {
+    const messages: unknown[] = [];
+    let messageListener: ((event: { data: unknown }) => void) | undefined;
+
+    const mockScope: OptimizerWorkerScopeLike = {
+      addEventListener: (_type, listener) => {
+        messageListener = listener as (event: { data: unknown }) => void;
+      },
+      postMessage: (message) => messages.push(message),
+    };
+
+    const controller = new OptimizerWorkerController(
+      mockScope,
+      async () => ({ status: "optimal", quantities: { corn: 50 } }),
+      100,
+    );
+
+    installOptimizerWorkerScope(mockScope, controller);
+
+    expect(messageListener).toBeDefined();
+    messageListener!({ data: request });
+
+    return Promise.resolve().then(() => {
+      expect(messages).toEqual([
+        expect.objectContaining({ type: "result", requestId: "request-1", status: "optimal", quantities: { corn: 50 } }),
+      ]);
+    });
+  });
+
+  it("cancels all active requests on dispose", () => {
+    const messages: unknown[] = [];
+    const controller = new OptimizerWorkerController(
+      { postMessage: (message) => messages.push(message) },
+      async () => new Promise(() => undefined), // never resolves
+      100,
+    );
+
+    controller.receive({ ...request, requestId: "req-a" });
+    controller.receive({ ...request, requestId: "req-b" });
+    controller.dispose();
+
+    expect(messages).toEqual([
+      { type: "cancelled", requestId: "req-a" },
+      { type: "cancelled", requestId: "req-b" },
+    ]);
   });
 });

--- a/v3-webapp/scripts/vite.optimizer-worker.config.ts
+++ b/v3-webapp/scripts/vite.optimizer-worker.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
       formats: ["es"],
       fileName: "optimizer-worker",
     },
-    outDir: resolve(import.meta.dirname, "../../../worker-bundle-proof"),
+    outDir: resolve(import.meta.dirname, "../dist/worker-bundle-proof"),
   },
 });


### PR DESCRIPTION
This change completes the isolated browser-worker lifecycle proof of concept for issue #125.

### Exact Files Touched
- `v3-webapp/scripts/vite.optimizer-worker.config.ts`: Corrected `outDir` path to build cleanly inside `v3-webapp/dist/worker-bundle-proof`.
- `v3-webapp/client/src/lib/optimizer-worker-controller.test.ts`: Added unit tests covering executor errors/exceptions, request sequencing, request ID reuse post-cancellation, worker scope listener installation, and controller disposal.

### Specific Changes Made
1. Fixed `outDir` in `vite.optimizer-worker.config.ts` from `../../../worker-bundle-proof` to `../dist/worker-bundle-proof` so `pnpm --dir v3-webapp test:optimizer-browser-bundle` builds within the sandbox workspace without permission errors.
2. Added unit tests to `optimizer-worker-controller.test.ts` testing:
   - Handling of executor error results and thrown exceptions (both `Error` instances and non-error objects).
   - Request sequencing and `requestId` reuse after request completion or cancellation.
   - `installOptimizerWorkerScope` event listener registration and dispatching.
   - Controller `dispose()` method cancelling active requests.

### User Impact
No user-facing impact. The proof of concept is completely isolated and is not imported by the active calculator UI or production bundle path.

### Validation
- `pnpm --dir v3-webapp check` (Type checking passed)
- `pnpm --dir v3-webapp test:calculator` (21 scenarios passed)
- `pnpm --dir v3-webapp test:optimizer-worker` (8 tests passed)
- `pnpm --dir v3-webapp test:optimizer-browser-bundle` (Build succeeded)
- `pnpm --dir v3-webapp build` (Production build succeeded)
- `pnpm --dir v3-webapp exec vitest run` (All 80 unit tests passed)

Fixes #140

---
*PR created automatically by Jules for task [5231593789199906257](https://jules.google.com/task/5231593789199906257) started by @Crypto-Shroom*