### PR TITLE
test(birds): enforce Pet/Companion profile default invariants

### DIFF
--- a/v3-webapp/client/src/lib/birds.test.ts
+++ b/v3-webapp/client/src/lib/birds.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { BIRD_CARE, BIRD_TYPES } from "./birds";
+import { BIRD_CARE, BIRD_PROFILES, BIRD_TYPES, getAvailableSituations } from "./birds";
+
+describe("canonical bird profiles and governance invariants", () => {
+  it("ensures 'Pet/Companion' profile exists for all birds and is default opening profile for non-pigeon birds", () => {
+    for (const bird of BIRD_TYPES) {
+      const birdProfile = BIRD_PROFILES[bird];
+      expect(birdProfile.profiles.pet).toBeDefined();
+      expect(birdProfile.profiles.pet.name).toBe("Pet/Companion");
+
+      if (bird !== "pigeon") {
+        const availableSituations = getAvailableSituations(bird);
+        expect(availableSituations[0]).toBe("pet");
+      }
+    }
+  });
+});
 
 describe("canonical bird care guidance", () => {
   it("provides the approved indoor-light care note for each supported bird", () => {


### PR DESCRIPTION
### User Impact & Summary
Adds automated unit test coverage in `v3-webapp/client/src/lib/birds.test.ts` to enforce repository governance rules:
1. Verifies that the `"Pet/Companion"` (`pet`) situation profile exists for all 6 supported bird species (Pigeon, Parrot, African Grey, Budgie, Canary, Chicken).
2. Verifies that `"Pet/Companion"` remains the default opening profile for all non-pigeon species (`getAvailableSituations(bird)[0] === 'pet'`).

This safeguards opening profile invariants against accidental regressions without modifying any runtime behavior, nutrition targets, or public copy.

### Files Touched
- `v3-webapp/client/src/lib/birds.test.ts`

### Concrete Changes
- Added a new `describe("canonical bird profiles and governance invariants")` test block with tests inspecting `BIRD_PROFILES` and `getAvailableSituations`.

### Validation Performed
- `pnpm --dir v3-webapp check` passed with 0 errors.
- `cd v3-webapp && pnpm vitest run` passed all 15 test files (77 tests).
- `pnpm test:provenance` passed all ledger validations.
- `pnpm --dir v3-webapp test:calculator` passed.
- `pnpm --dir v3-webapp test:herb-safety` passed.
- `pnpm --dir v3-webapp build` completed cleanly.

---
*PR created automatically by Jules for task [17210532521411334783](https://jules.google.com/task/17210532521411334783) started by @Crypto-Shroom*